### PR TITLE
ACM-30524: Add autonomous Gmail triage with batch operations and interactive dashboard

### DIFF
--- a/.claude/commands/emails.md
+++ b/.claude/commands/emails.md
@@ -1,200 +1,91 @@
 ---
-argument-hint: Day reference, like today, tomorrow, yesterday, next Tuesday
-description: Lists Google Calendar events
-allowed-tools: [list_unread_emails, delete_email, archive_email]
+argument-hint: Optional subject filter or keyword
+description: List and organize inbox emails with Gmail labels and links
+allowed-tools: [mcp__gmail__list_unread_emails, mcp__gmail__delete_emails, mcp__gmail__archive_emails, mcp__gmail__modify_labels, mcp__gmail__list_labels, mcp__gmail__create_label, mcp__gmail__list_recent_actions]
 ---
 
-You are a Gmail management assistant powered by the gmail-mcp-server MCP tools. Your primary function is to help users efficiently manage their Gmail inbox with intelligent filtering, categorization, and automated actions.
+You are a Gmail management assistant. Your job is to fetch unread emails, organize them into labeled groups in Gmail, and output a concise dashboard with clickable Gmail links so the user can review each group directly in Gmail's UI.
 
-## Primary Workflows
+## Step 1: Fetch Emails and Labels
 
-#### Step 1: Gather and Analyze
-- **List emails**
-- **Default to searching INBOX folder** unless user specifies a different folder
-- **Receive raw email data** from MCP as simple numbered list with subjects, senders, dates, and body content
-- **Generate one-line summary from email body** for each email
-- **Compare summary quality to subject line** - determine if summary provides better context
-- **Assign priority rating** based on content analysis: Minor, Good to Know, or Major
+1. Call `list_unread_emails`. If an argument was provided, use it as `subject_filter`.
+2. Call `list_labels` to get the current label list.
 
-#### Step 2: Dynamic Grouping
-After analyzing all emails and creating summaries:
-- **Analyze subjects and summaries** to identify natural groupings and patterns
-- **Create dynamic group headers** based on actual email content rather than predefined categories
-- **Group related emails together** using intelligent categorization (e.g., "Project Alpha Updates", "Security Alerts", "Meeting Requests", "Code Reviews")
-- **Maintain original email numbering** from the MCP response throughout the grouping process
-- **CRITICAL: Preserve email number to message_id mapping** - the numbered positions must remain consistent for action commands
+## Step 2: Analyze and Group
 
-#### Step 3: Display Format
-Present in this dynamic format:
+Analyze all emails and assign each to a group:
+
+1. **Generate a one-line summary** from each email's body content
+2. **Assign priority**: Critical, Important, or Info
+3. **Group into meaningful categories** based on content patterns — aim for 3-8 groups
+
+### Dynamic Group Creation
+- Analyze subjects, senders, and bodies to find natural clusters
+- Use descriptive names: "Security Alerts", "Code Reviews", "Jira/ACM", "Team Discussions"
+- All groups use the `Triage/` label prefix (e.g., `Triage/Security`, `Triage/Reviews`)
+
+### Jira Email Handling
+For emails with `[RH Jira]` or Jira ticket patterns:
+- **Always extract the JIRA ID** (e.g., `ACM-27253`)
+- **Trivial field changes** (status, assignee, priority, fix version) → auto-delete, skip labeling
+- **Substantive content** → label under `Triage/Jira` and include JIRA ID in report
+
+### Auto-Clean Rules
+- **Calendar/meeting invites** → auto-archive (no label needed)
+- **Trivial Jira field changes** → auto-delete (no label needed)
+
+## Step 3: Apply Labels
+
+For each `Triage/*` group:
+1. Check if the label exists (from Step 1)
+2. If not, call `create_label`
+3. Call `modify_labels` with `positions: [...]` and `add_labels: ["Triage/GroupName"]`
+
+Then execute auto-clean actions:
+- `delete_emails` for trivial Jira changes
+- `archive_emails` for calendar invites
+
+## Step 4: Output Dashboard
+
+Output a concise summary with Gmail links. Do NOT list every email — just group summaries.
+
+Gmail search URL format:
+`https://mail.google.com/mail/u/0/#search/in%3Ainbox+label%3ATriage%2F<GroupName>`
+(URL-encode: `/` → `%2F`, spaces → `+`)
+
 ```
-Found X unread emails:
+INBOX SUMMARY
 
-[Dynamic Group Name]:
-1: [Subject line] - Major
-   → Better summary from email body (if summary is superior)
-2: [Subject line] - Minor
+Auto-cleaned:
+  Deleted: [N] trivial Jira field changes
+  Archived: [N] calendar/meeting invites
 
-[Another Dynamic Group Name]:
-3: [Subject line] - Good to Know
-   → Detailed summary explaining the actual request
-```
+Labels applied:
 
-#### Email Number Tracking Rules:
-- **NEVER renumber emails** - use the exact numbering from the MCP response
-- **Preserve position-to-message_id mapping** - email actions depend on original numbering
-- **Sequential numbering across groups** - if MCP returns emails 1-10, maintain 1-10 regardless of grouping
-- **Reference integrity** - users must be able to say "archive email 5" and have it work correctly
+[Priority] Triage/Jira ([N] emails)
+  Substantive Jira activity — comments, new issues, resolutions
+  [JIRA-ID]: [one-line summary] — [sender]
+  [JIRA-ID]: [one-line summary] — [sender]
+  → https://mail.google.com/mail/u/0/#search/in%3Ainbox+label%3ATriage%2FJira
 
-### 2. Email Summary and Priority Analysis
+[Priority] Triage/GroupName ([N] emails)
+  [Brief description of what's in this group]
+  → https://mail.google.com/mail/u/0/#search/in%3Ainbox+label%3ATriage%2FGroupName
 
-#### Summary Generation Rules:
-- **Analyze email body content** to extract key information
-- **Generate concise one-line summary** focusing on actionable items or key updates
-- **Compare summary to subject line** for clarity and usefulness
-- **Use summary instead of subject** if it provides better context or is more informative
-- **Maintain proper indentation** (→ prefix) when displaying summary on next line
-
-#### Three-Tier Priority System:
-- **Minor**: Routine updates, FYI items, minor changes, acknowledgments
-- **Good to Know**: Relevant information, moderate priority items, useful updates
-- **Major**: Critical issues, urgent actions required, important decisions, high-impact changes
-
-## Priority Rating Guidelines
-
-### Minor Priority Indicators:
-- Routine status updates with minimal changes
-- Automated notifications with no action required
-- Single-word field changes (assignee, status, etc.)
-- Social media notifications
-- Calendar confirmations
-- FYI communications
-
-### Good to Know Priority Indicators:
-- Project updates requiring awareness
-- Meeting notes or summaries
-- Feature requests or enhancement discussions
-- Non-critical bug reports
-- Process changes or policy updates
-- Relevant industry news or updates
-
-### Major Priority Indicators:
-- Critical system failures or outages
-- Security vulnerabilities or incidents
-- Urgent action items with deadlines
-- Production issues affecting users
-- High-impact project decisions
-- Emergency communications
-- Critical bug reports
-
-#### Special Handling for Jira Emails
-When processing emails with "[RH Jira]" in the subject line, apply these additional rules:
-
-- **Major Priority for Jira:**
-    - Critical issues, security vulnerabilities, production outages
-    - Substantive new comments (at least a full sentence, not just minor word edits)
-    - New bug reports or feature requests requiring immediate attention
-
-- **Good to Know Priority for Jira:**
-    - Feature requests, non-critical bug reports
-    - General discussions in comments
-    - Project updates and milestone notifications
-
-- **Minor Priority for Jira (Always include a summary of the change):**
-    - Workflow status changes (e.g., `New` -> `In Progress`)
-    - Priority changes
-    - `Fix Version` field updates
-    - Status changes to `Closed`
-    - Other single-word/single-line changes (e.g., assignee, labels)
-    - **Suggest deletion for routine administrative changes** like `Fix Version` updates and status changes to `Closed`
-
-### 3. Automated Actions Suggestions
-
-#### Automatic Deletion Targets:
-- **Minor Jira updates** - Suggest deletion for single-word/single-line changes in JIRA issues (status changes, assignee updates, etc.)
-- **Social media notifications** - LinkedIn, Facebook, Twitter notifications
-- **Automated system alerts** - Routine system notifications with no action required
-- **Spam and promotional emails** - Marketing emails, newsletters (unless specifically requested)
-
-#### Automatic Archive Suggestions:
-- **Calendar emails** - Meeting invites, calendar updates, scheduling notifications
-- **Automated notifications** - CI/CD reports, system alerts (unless they contain errors)
-- **Newsletter subscriptions** - Regular newsletters and updates
-- **Completed project notifications** - Status updates for completed work
-
-### 4. Action Commands
-Users can reference emails by their numbered position:
-- "Archive email 3" → Use email ID from position 3 in the list
-- "Delete emails 1, 5, 7" → Handle multiple emails by their list positions
-
-## Response Format Guidelines
-
-### Email Listing Response:
-```
-Found X unread emails:
-
-Project Updates:
-1: [RH Jira] Bug Report: Critical authentication failure - Major
-2: [RH Jira] New ticket assigned: Database connection issue - Good to Know
-3: [RH Jira] Status Update: VIRTSTRAT-123 - Minor
-   → Status changed from "Open" to "In Progress"
-🗑️ DELETE email 3 (minor status update)
-
-Team Communications:
-4: Question about project timeline - Good to Know
-   → Manager asking for Q4 delivery estimates and resource planning
-5: Code review feedback needed - Minor
-
-Calendar & Scheduling:
-6: Meeting: Standup tomorrow at 9AM - Minor
-7: All-hands meeting moved to Friday - Good to Know
-📅 ARCHIVE ALL (routine scheduling updates)
-
-System Alerts:
-8: Cluster Service Error: Provisioning failed for cluster XYZ - Major
-⚠️ REVIEW email 8 (requires immediate attention)
-
-Social & Promotional:
-9: LinkedIn: New connection request from John Doe - Minor
-10: Newsletter: Weekly Tech Updates - Minor
-🗑️ DELETE emails 9,10 (social media and promotional)
-
-Security & Critical:
-11: Critical security patch available - Major
-⚠️ REVIEW email 11 (requires attention)
+TOTALS: [deleted] deleted, [archived] archived, [labeled] labeled across [N] groups
 ```
 
-### Action Confirmations:
-- "✅ Archived email 2: [Subject]"
-- "🗑️ Deleted email 3: [Subject]"
-- "❌ Failed to archive email 1: [Error reason]"
+## Key Rules
 
-## Dynamic Email Grouping Strategy
-Instead of predefined categories, create intelligent groups based on email content:
+- **Every remaining email gets a label** — nothing left unlabeled
+- **JIRA IDs are mandatory** in Jira report lines
+- **Keep it concise** — group summaries, not per-email listings (except Jira IDs)
+- **Gmail links are required** for every label group
+- **Process ALL emails** — do not skip any
 
-### Dynamic Group Creation:
-- **Analyze email subjects and summaries** to identify natural patterns and relationships
-- **Create contextual group names** that reflect actual email content (e.g., "Database Migration Project", "Q4 Planning", "Security Incident Response")
-- **Group related emails together** regardless of sender or email type
-- **Use descriptive group headers** that help users understand the common theme
+## Action Commands
 
-### Group Header Examples:
-- **Project-based**: "Project Alpha Updates", "Database Migration", "Website Redesign"
-- **Topic-based**: "Security Alerts", "Performance Issues", "Code Reviews"
-- **Urgency-based**: "Urgent Action Required", "FYI Updates", "Routine Notifications"
-- **Sender-based**: "Team Lead Communications", "External Vendor Updates"
-- **Time-sensitive**: "Meeting Requests", "Deadline Reminders", "Calendar Updates"
-
-### Grouping Rules:
-- **Prioritize meaningful groups** over generic categories
-- **Maintain sequential numbering** across all groups for easy reference (CRITICAL)
-- **No individual source labels** when emails are grouped (avoid redundancy)
-- **Show group-level recommendations** when multiple emails of same type have similar actions
-- **Flexible group ordering** based on priority and relevance rather than fixed hierarchy
-
-### Group-Level Recommendation Rules:
-- **When recommending action for entire group**: Use format `📅 [Group Name]: ARCHIVE ALL (reason)` to indicate all emails in that group
-- **When recommending action for specific emails**: Use format `🗑️ DELETE emails 2,4 (reason)` with specific numbers
-- **Mixed recommendations within group**: Give individual email recommendations rather than group-level
-- **Group recommendations without specific email numbers** = applies to ALL emails in that group
-- **Individual email numbers** = only those specific emails referenced
-
+Users can take follow-up actions by position number:
+- "Archive emails 3, 5" → `archive_emails` with `positions: [3, 5]`
+- "Delete emails 1, 7" → `delete_emails` with `positions: [1, 7]`
+- "Label 1, 3 as 'Urgent'" → `modify_labels` with `positions: [1, 3]`, `add_labels: ["Urgent"]`

--- a/.claude/commands/triage.md
+++ b/.claude/commands/triage.md
@@ -1,0 +1,120 @@
+---
+description: Intelligently triage inbox - label, organize, and summarize emails for Gmail review
+argument-hint: Optional - max number of emails to process
+allowed-tools: [mcp__gmail__list_unread_emails, mcp__gmail__delete_emails, mcp__gmail__archive_emails, mcp__gmail__modify_labels, mcp__gmail__list_labels, mcp__gmail__create_label, mcp__gmail__list_recent_actions]
+---
+
+You are an autonomous inbox manager. Process all unread emails, apply Gmail labels for organization, auto-delete obvious noise, and output a concise dashboard with Gmail links. Execute actions immediately without asking for confirmation.
+
+## Step 1: Fetch Emails and Labels
+
+1. Call `list_unread_emails` to get all unread emails. If an argument was provided, use it as `max_results`.
+2. Call `list_labels` to get the current label list (you'll need this for creating/reusing labels).
+
+## Step 2: Classify Every Email
+
+Process every email and assign it to exactly one group. Use the rules below in order.
+
+### Rule 1: Calendar / Meeting Invites → AUTO-ARCHIVE
+- Emails from Google Calendar, meeting invitations, RSVPs, scheduling updates
+- **NOT** meeting notes, sync notes, or recap emails (e.g., "Weekly Sync notes") — these are team content, not calendar noise. Label them into an appropriate group instead.
+- **Action**: Archive immediately (no label needed — these are noise)
+
+### Rule 2: Jira Emails — Extract JIRA ID, Then Sub-classify
+For any email with `[RH Jira]` or a Jira ticket pattern (e.g., `ACM-12345`, `FCN-134`, `OCPBUGS-999`):
+
+#### 2a: Trivial Field Changes → AUTO-DELETE
+- Status changes, assignee changes, priority changes, fix version, sprint updates
+- Any update that is just a field value change with no prose
+- **Action**: Delete immediately (no label needed — these are noise)
+
+#### 2b: Jira Activity (substantive) → LABEL
+- Comments with at least one sentence of content, new issues, resolution comments, bug reports
+- Short status comments ("DONE", "Fixed", "Resolved") also go here
+- **Group label**: `Triage/Jira`
+- Record the JIRA ID and a brief summary for the report
+
+### Rule 3: All Other Emails → Classify into Groups
+Analyze subjects, senders, and body content to create meaningful groups. Examples:
+- `Triage/Security` — security alerts, vulnerability notices
+- `Triage/Reviews` — code reviews, PR notifications
+- `Triage/Team` — team discussions, project updates, direct messages
+- `Triage/Notifications` — automated notifications, CI/CD, system alerts
+- `Triage/External` — vendor emails, external communications
+
+Create groups dynamically based on actual email content. Use your judgment — aim for 3-8 groups total (not one per email). Every non-deleted, non-archived email must land in a `Triage/*` group.
+
+### Priority Assignment
+Assign each group a priority:
+- **Critical** — requires action today (security, production issues, urgent deadlines)
+- **Important** — should review soon (project discussions, decisions, substantive Jira)
+- **Info** — awareness only (FYI, newsletters, routine notifications)
+
+## Step 3: Execute Actions
+
+### 3a: Auto-delete and auto-archive
+- Call `delete_emails` with all trivial Jira field-change positions
+- Call `archive_emails` with all calendar/meeting invite positions
+
+### 3b: Create labels and apply them
+For each `Triage/*` group:
+1. Check if the label already exists (from Step 1 label list)
+2. If not, call `create_label` to create it
+3. Call `modify_labels` with `positions: [...]` and `add_labels: ["Triage/GroupName"]` to apply the label to all emails in that group
+
+## Step 4: Generate Dashboard
+
+Output a concise dashboard. For each group, include a clickable Gmail link.
+
+The Gmail search URL format is:
+`https://mail.google.com/mail/u/0/#search/in%3Ainbox+label%3ATriage%2F<GroupName>`
+(URL-encode: `/` → `%2F`, spaces → `+`, `:` → `%3A`)
+
+**Important**: Use `in:inbox` NOT `is:unread` — this shows all inbox messages with that label, so messages don't disappear after being read.
+
+```
+INBOX TRIAGE COMPLETE
+
+Labels applied:
+
+[Priority] Triage/Jira ([N] emails)
+  Jira activity requiring review — comments, new issues, resolutions
+  [JIRA-ID]: [one-line summary] — [sender]
+  [JIRA-ID]: [one-line summary] — [sender]
+  ...
+
+[Priority] Triage/Security ([N] emails)
+  Security alerts and vulnerability notices
+
+[Priority] Triage/GroupName ([N] emails)
+  [Brief description of what's in this group]
+
+Auto-cleaned:
+
+  Archived: [N] calendar/meeting invites
+
+  Deleted ([N]):
+  - [JIRA-ID]: [1-2 sentence summary of what was in the email and why it was deleted]
+  - [JIRA-ID]: [1-2 sentence summary]
+  - ...
+
+TOTALS: [deleted] deleted, [archived] archived, [labeled] labeled across [N] groups
+
+---
+QUICK LINKS:
+  Triage/Jira          ([N]) → https://mail.google.com/mail/u/0/#search/in%3Ainbox+label%3ATriage%2FJira
+  Triage/Security      ([N]) → https://mail.google.com/mail/u/0/#search/in%3Ainbox+label%3ATriage%2FSecurity
+  Triage/GroupName     ([N]) → https://mail.google.com/mail/u/0/#search/in%3Ainbox+label%3ATriage%2FGroupName
+```
+
+## Key Rules
+
+- **Every remaining email gets a label** — nothing should be left unlabeled in the inbox
+- **JIRA IDs are mandatory** in all Jira-related report lines
+- **Execute without asking** — this is an autonomous triage system
+- **When in doubt about a Jira email**: label it (don't delete) and report it
+- **Process ALL emails** — do not skip any
+- **Every deleted email gets a 1-2 sentence summary** — so the user can judge if the deletion was correct
+- **Keep the dashboard concise** — one line per Jira ticket, one line description per group
+- **Groups should be meaningful** — merge tiny groups, split large ones. Aim for 3-8 groups.
+- **QUICK LINKS table is required** — must appear at the very end with every label, its count, and a clickable Gmail link using `in:inbox` (not `is:unread`)

--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,5 @@ GEMINI.md
 ./gemini
 !./gemini/commands/
 .sync-commands/
+logs/
+tests/test_server.py

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,9 @@
+.PHONY: triage watch
+
+MODEL ?= haiku
+
+triage:
+	./scripts/inbox-manager.sh --model $(MODEL)
+
+watch:
+	./scripts/inbox-manager.sh --watch 10 --model $(MODEL)

--- a/gmail_mcp_server/gmail_client.py
+++ b/gmail_mcp_server/gmail_client.py
@@ -15,12 +15,12 @@ from googleapiclient.errors import HttpError
 
 class GmailClient:
     """Gmail API client for managing emails."""
-    
+
     SCOPES = [
         'https://www.googleapis.com/auth/gmail.readonly',
         'https://www.googleapis.com/auth/gmail.modify'
     ]
-    
+
     def __init__(self, credentials_path: str = "credentials.json", token_path: str = "token.json", auto_authenticate: bool = False):
         """Initialize Gmail client with authentication."""
         # Get the directory where this code file resides
@@ -42,7 +42,7 @@ class GmailClient:
 
         if auto_authenticate:
             self._authenticate()
-    
+
     def _authenticate(self):
         """Authenticate and build Gmail service."""
         creds = None
@@ -97,7 +97,7 @@ class GmailClient:
         """Ensure the client is authenticated before making API calls."""
         if not self._authenticated:
             self._authenticate()
-    
+
     def list_unread_emails(self, subject_filter: Optional[str] = None, max_results: int = 50) -> List[Dict[str, Any]]:
         """
         List unread emails in inbox, optionally filtered by subject.
@@ -107,33 +107,33 @@ class GmailClient:
             max_results: Maximum number of emails to return
 
         Returns:
-            List of email dictionaries with id, subject, sender, date, and body
+            List of email dictionaries with id, threadId, labelIds, subject, sender, date, and body
         """
         self._ensure_authenticated()
         try:
             query = "is:unread in:inbox"
             if subject_filter:
                 query += f' subject:"{subject_filter}"'
-            
+
             result = self.service.users().messages().list(
                 userId='me',
                 q=query,
                 maxResults=max_results
             ).execute()
-            
+
             messages = result.get('messages', [])
             emails = []
-            
+
             for message in messages:
                 email_data = self._get_email_details(message['id'])
                 if email_data:
                     emails.append(email_data)
-            
+
             return emails
-            
+
         except HttpError as error:
             raise Exception(f"An error occurred while listing emails: {error}")
-    
+
     def _get_email_details(self, message_id: str) -> Optional[Dict[str, Any]]:
         """Get detailed information about a specific email."""
         self._ensure_authenticated()
@@ -143,31 +143,33 @@ class GmailClient:
                 id=message_id,
                 format='full'
             ).execute()
-            
+
             headers = message['payload'].get('headers', [])
             subject = next((h['value'] for h in headers if h['name'] == 'Subject'), 'No Subject')
             sender = next((h['value'] for h in headers if h['name'] == 'From'), 'Unknown Sender')
             date = next((h['value'] for h in headers if h['name'] == 'Date'), 'Unknown Date')
-            
+
             body = self._extract_email_body(message['payload'])
-            
+
             return {
                 'id': message_id,
+                'threadId': message.get('threadId', ''),
+                'labelIds': message.get('labelIds', []),
                 'subject': subject,
                 'sender': sender,
                 'date': date,
                 'body': body,
                 'snippet': message.get('snippet', '')
             }
-            
+
         except HttpError as error:
             print(f"An error occurred while getting email details: {error}")
             return None
-    
+
     def _extract_email_body(self, payload: Dict[str, Any]) -> str:
         """Extract email body from message payload."""
         body = ""
-        
+
         if 'parts' in payload:
             for part in payload['parts']:
                 if part['mimeType'] == 'text/plain':
@@ -184,12 +186,188 @@ class GmailClient:
                 data = payload['body'].get('data', '')
                 if data:
                     body = base64.urlsafe_b64decode(data).decode('utf-8')
-        
+
         return body or "No readable content"
-    
-    def delete_email(self, message_id: str) -> dict:
+
+    def list_labels(self) -> List[Dict[str, str]]:
+        """List all Gmail labels.
+
+        Returns:
+            List of dicts with id, name, type keys.
         """
-        Move an email to trash and mark it as read.
+        self._ensure_authenticated()
+        try:
+            result = self.service.users().labels().list(userId='me').execute()
+            labels = result.get('labels', [])
+            return [{'id': l['id'], 'name': l['name'], 'type': l.get('type', '')} for l in labels]
+        except HttpError as error:
+            raise Exception(f"An error occurred while listing labels: {error}")
+
+    def create_label(self, name: str, background_color: str = None, text_color: str = None) -> Dict[str, str]:
+        """Create a new Gmail label.
+
+        Args:
+            name: The label name to create.
+            background_color: Optional hex color for label background (e.g. '#4a86e8').
+            text_color: Optional hex color for label text (e.g. '#ffffff').
+
+        Returns:
+            Dict with id and name of the created label.
+        """
+        self._ensure_authenticated()
+        try:
+            label_body = {
+                'name': name,
+                'labelListVisibility': 'labelShow',
+                'messageListVisibility': 'show'
+            }
+            if background_color and text_color:
+                label_body['color'] = {
+                    'backgroundColor': background_color,
+                    'textColor': text_color
+                }
+            result = self.service.users().labels().create(userId='me', body=label_body).execute()
+            return {'id': result['id'], 'name': result['name']}
+        except HttpError as error:
+            raise Exception(f"An error occurred while creating label: {error}")
+
+    def _resolve_label_name_to_id(self, name: str) -> str:
+        """Resolve a label name to its ID (case-insensitive).
+
+        Args:
+            name: Label name to resolve.
+
+        Returns:
+            The label ID.
+
+        Raises:
+            ValueError: If the label name is not found.
+        """
+        labels = self.list_labels()
+        name_lower = name.lower()
+        for label in labels:
+            if label['name'].lower() == name_lower:
+                return label['id']
+        raise ValueError(f"Label not found: {name}")
+
+    def modify_labels(self, message_ids: List[str], add_labels: List[str] = None, remove_labels: List[str] = None) -> List[Dict[str, Any]]:
+        """Batch add/remove labels on messages.
+
+        Args:
+            message_ids: List of message IDs to modify.
+            add_labels: Label names to add.
+            remove_labels: Label names to remove.
+
+        Returns:
+            List of result dicts with success, message_id, and error fields.
+        """
+        self._ensure_authenticated()
+        add_ids = [self._resolve_label_name_to_id(n) for n in (add_labels or [])]
+        remove_ids = [self._resolve_label_name_to_id(n) for n in (remove_labels or [])]
+
+        results = []
+        for mid in message_ids:
+            try:
+                body = {}
+                if add_ids:
+                    body['addLabelIds'] = add_ids
+                if remove_ids:
+                    body['removeLabelIds'] = remove_ids
+                self.service.users().messages().modify(userId='me', id=mid, body=body).execute()
+                results.append({'success': True, 'message_id': mid, 'error': None})
+            except HttpError as error:
+                results.append({'success': False, 'message_id': mid, 'error': str(error)})
+        return results
+
+    def mark_as_read(self, message_ids: List[str]) -> List[Dict[str, Any]]:
+        """Batch mark messages as read by removing the UNREAD label.
+
+        Args:
+            message_ids: List of message IDs to mark as read.
+
+        Returns:
+            List of result dicts with success, message_id, and error fields.
+        """
+        self._ensure_authenticated()
+        results = []
+        for mid in message_ids:
+            try:
+                self.service.users().messages().modify(
+                    userId='me', id=mid,
+                    body={'removeLabelIds': ['UNREAD']}
+                ).execute()
+                results.append({'success': True, 'message_id': mid, 'error': None})
+            except HttpError as error:
+                results.append({'success': False, 'message_id': mid, 'error': str(error)})
+        return results
+
+    def delete_emails(self, message_ids: List[str]) -> List[Dict[str, Any]]:
+        """Batch move emails to trash and mark as read.
+
+        Args:
+            message_ids: List of message IDs to trash.
+
+        Returns:
+            List of result dicts with success, subject, message_id, and error fields.
+        """
+        self._ensure_authenticated()
+        results = []
+        for mid in message_ids:
+            try:
+                email_details = self._get_email_details(mid)
+                subject = email_details.get('subject', 'No Subject') if email_details else 'Unknown Subject'
+                if len(subject) > 60:
+                    subject = subject[:57] + "..."
+
+                self.service.users().messages().modify(
+                    userId='me', id=mid,
+                    body={
+                        'addLabelIds': ['TRASH'],
+                        'removeLabelIds': ['UNREAD']
+                    }
+                ).execute()
+                results.append({'success': True, 'subject': subject, 'message_id': mid, 'error': None})
+            except HttpError as error:
+                error_details = f"HTTP {error.resp.status}: {error.error_details if hasattr(error, 'error_details') else str(error)}"
+                results.append({'success': False, 'subject': None, 'message_id': mid, 'error': error_details})
+            except Exception as error:
+                error_details = f"Unexpected error: {str(error)} ({type(error).__name__})"
+                results.append({'success': False, 'subject': None, 'message_id': mid, 'error': error_details})
+        return results
+
+    def archive_emails(self, message_ids: List[str]) -> List[Dict[str, Any]]:
+        """Batch archive emails (remove from inbox).
+
+        Args:
+            message_ids: List of message IDs to archive.
+
+        Returns:
+            List of result dicts with success, subject, message_id, and error fields.
+        """
+        self._ensure_authenticated()
+        results = []
+        for mid in message_ids:
+            try:
+                email_details = self._get_email_details(mid)
+                subject = email_details.get('subject', 'No Subject') if email_details else 'Unknown Subject'
+                if len(subject) > 60:
+                    subject = subject[:57] + "..."
+
+                self.service.users().messages().modify(
+                    userId='me', id=mid,
+                    body={'removeLabelIds': ['INBOX', 'UNREAD']}
+                ).execute()
+                results.append({'success': True, 'subject': subject, 'message_id': mid, 'error': None})
+            except HttpError as error:
+                error_details = f"HTTP {error.resp.status}: {error.error_details if hasattr(error, 'error_details') else str(error)}"
+                results.append({'success': False, 'subject': None, 'message_id': mid, 'error': error_details})
+            except Exception as error:
+                error_details = f"Unexpected error: {str(error)} ({type(error).__name__})"
+                results.append({'success': False, 'subject': None, 'message_id': mid, 'error': error_details})
+        return results
+
+    def delete_email(self, message_id: str) -> dict:
+        """Move an email to trash and mark it as read.
 
         Args:
             message_id: The ID of the email to move to trash
@@ -197,38 +375,10 @@ class GmailClient:
         Returns:
             Dict with 'success' bool, 'subject' string, and 'error' string if failed
         """
-        self._ensure_authenticated()
-        try:
-            # Get email subject before deleting
-            email_details = self._get_email_details(message_id)
-            subject = email_details.get('subject', 'No Subject') if email_details else 'Unknown Subject'
+        return self.delete_emails([message_id])[0]
 
-            # Truncate subject to prevent line wrapping (max 60 characters)
-            if len(subject) > 60:
-                subject = subject[:57] + "..."
-
-            self.service.users().messages().modify(
-                userId='me',
-                id=message_id,
-                body={
-                    'addLabelIds': ['TRASH'],
-                    'removeLabelIds': ['UNREAD']
-                }
-            ).execute()
-            return {"success": True, "subject": subject, "error": None}
-
-        except HttpError as error:
-            error_details = f"HTTP {error.resp.status}: {error.error_details if hasattr(error, 'error_details') else str(error)}"
-            print(f"An error occurred while moving email to trash: {error_details}")
-            return {"success": False, "subject": None, "error": error_details}
-        except Exception as error:
-            error_details = f"Unexpected error: {str(error)} ({type(error).__name__})"
-            print(f"An error occurred while moving email to trash: {error_details}")
-            return {"success": False, "subject": None, "error": error_details}
-    
     def archive_email(self, message_id: str) -> dict:
-        """
-        Archive an email (remove from inbox).
+        """Archive an email (remove from inbox).
 
         Args:
             message_id: The ID of the email to archive
@@ -236,28 +386,4 @@ class GmailClient:
         Returns:
             Dict with 'success' bool, 'subject' string, and 'error' string if failed
         """
-        self._ensure_authenticated()
-        try:
-            # Get email subject before archiving
-            email_details = self._get_email_details(message_id)
-            subject = email_details.get('subject', 'No Subject') if email_details else 'Unknown Subject'
-
-            # Truncate subject to prevent line wrapping (max 60 characters)
-            if len(subject) > 60:
-                subject = subject[:57] + "..."
-
-            self.service.users().messages().modify(
-                userId='me',
-                id=message_id,
-                body={'removeLabelIds': ['INBOX', 'UNREAD']}
-            ).execute()
-            return {"success": True, "subject": subject, "error": None}
-
-        except HttpError as error:
-            error_details = f"HTTP {error.resp.status}: {error.error_details if hasattr(error, 'error_details') else str(error)}"
-            print(f"An error occurred while archiving email: {error_details}")
-            return {"success": False, "subject": None, "error": error_details}
-        except Exception as error:
-            error_details = f"Unexpected error: {str(error)} ({type(error).__name__})"
-            print(f"An error occurred while archiving email: {error_details}")
-            return {"success": False, "subject": None, "error": error_details}
+        return self.archive_emails([message_id])[0]

--- a/gmail_mcp_server/server.py
+++ b/gmail_mcp_server/server.py
@@ -3,20 +3,30 @@
 import asyncio
 import json
 import os
+import re
+from collections import OrderedDict
+from datetime import datetime
 from typing import Any, Sequence
 from mcp.server import Server
 from mcp.server.models import InitializationOptions
 from mcp.server import NotificationOptions
 from mcp.server.stdio import stdio_server
 from mcp.types import (
-    Resource, 
-    Tool, 
-    TextContent, 
-    ImageContent, 
+    Resource,
+    Tool,
+    TextContent,
+    ImageContent,
     EmbeddedResource
 )
 from pydantic import AnyUrl
 from .gmail_client import GmailClient
+
+# Standard Gmail labels to hide from display
+_HIDDEN_LABELS = {
+    'INBOX', 'UNREAD', 'SPAM', 'TRASH', 'DRAFT', 'SENT', 'STARRED',
+    'IMPORTANT', 'CHAT', 'CATEGORY_PERSONAL', 'CATEGORY_SOCIAL',
+    'CATEGORY_PROMOTIONS', 'CATEGORY_UPDATES', 'CATEGORY_FORUMS',
+}
 
 
 class GmailMCPServer:
@@ -26,11 +36,44 @@ class GmailMCPServer:
         self.server = Server("gmail-mcp-server")
         self.gmail_client = None
         self.email_position_map = {}  # Maps position numbers to email IDs
+        self.recent_actions = []  # In-memory action log
         self._setup_handlers()
-    
+
+    def _record_action(self, action: str, subject: str, message_id: str):
+        """Record an action to the in-memory log (capped at 100)."""
+        self.recent_actions.append({
+            'timestamp': datetime.now().isoformat(),
+            'action': action,
+            'subject': subject,
+            'message_id': message_id,
+        })
+        if len(self.recent_actions) > 100:
+            self.recent_actions = self.recent_actions[-100:]
+
+    def _resolve_message_ids(self, arguments: dict) -> list[str]:
+        """Resolve positions[] and/or message_ids[] into a flat list of message IDs."""
+        ids = list(arguments.get('message_ids', []) or [])
+        for pos in (arguments.get('positions', []) or []):
+            if pos not in self.email_position_map:
+                raise ValueError(f"Position {pos} not found in current email list. Please run 'list_unread_emails' first.")
+            ids.append(self.email_position_map[pos])
+        if not ids:
+            # Fallback: support single position/message_id for backwards compat
+            mid = arguments.get('message_id')
+            pos = arguments.get('position')
+            if mid:
+                ids.append(mid)
+            elif pos is not None:
+                if pos not in self.email_position_map:
+                    raise ValueError(f"Position {pos} not found in current email list. Please run 'list_unread_emails' first.")
+                ids.append(self.email_position_map[pos])
+        if not ids:
+            raise ValueError("No message IDs or positions provided.")
+        return ids
+
     def _setup_handlers(self):
         """Set up MCP server handlers."""
-        
+
         @self.server.list_tools()
         async def handle_list_tools() -> list[Tool]:
             """List available tools."""
@@ -54,55 +97,124 @@ class GmailMCPServer:
                     }
                 ),
                 Tool(
-                    name="delete_email",
-                    description="Move an email to trash and mark it as read by ID or position number",
+                    name="delete_emails",
+                    description="Move emails to trash and mark as read. Accepts positions[] from email list and/or message_ids[].",
                     inputSchema={
                         "type": "object",
                         "properties": {
-                            "message_id": {
-                                "type": "string",
-                                "description": "The Gmail message ID to move to trash (alternative to position)"
+                            "positions": {
+                                "type": "array",
+                                "items": {"type": "integer"},
+                                "description": "Position numbers from the email list"
                             },
-                            "position": {
-                                "type": "integer",
-                                "description": "The numbered position from the email list (alternative to message_id)"
-                            },
-                            "subject": {
-                                "type": "string",
-                                "description": "The email subject (for display purposes during approval)"
+                            "message_ids": {
+                                "type": "array",
+                                "items": {"type": "string"},
+                                "description": "Gmail message IDs"
                             }
                         }
                     }
                 ),
                 Tool(
-                    name="archive_email",
-                    description="Archive an email (remove from inbox) by ID or position number",
+                    name="archive_emails",
+                    description="Archive emails (remove from inbox). Accepts positions[] from email list and/or message_ids[].",
                     inputSchema={
                         "type": "object",
                         "properties": {
-                            "message_id": {
-                                "type": "string",
-                                "description": "The Gmail message ID to archive (alternative to position)"
+                            "positions": {
+                                "type": "array",
+                                "items": {"type": "integer"},
+                                "description": "Position numbers from the email list"
                             },
-                            "position": {
-                                "type": "integer",
-                                "description": "The numbered position from the email list (alternative to message_id)"
-                            },
-                            "subject": {
-                                "type": "string",
-                                "description": "The email subject (for display purposes during approval)"
+                            "message_ids": {
+                                "type": "array",
+                                "items": {"type": "string"},
+                                "description": "Gmail message IDs"
                             }
                         }
                     }
-                )
+                ),
+                Tool(
+                    name="list_labels",
+                    description="List all Gmail labels",
+                    inputSchema={
+                        "type": "object",
+                        "properties": {}
+                    }
+                ),
+                Tool(
+                    name="create_label",
+                    description="Create a new Gmail label",
+                    inputSchema={
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "type": "string",
+                                "description": "The label name to create"
+                            },
+                            "background_color": {
+                                "type": "string",
+                                "description": "Hex background color (e.g. '#4a86e8'). Must be used with text_color. Only predefined Gmail colors are accepted."
+                            },
+                            "text_color": {
+                                "type": "string",
+                                "description": "Hex text color (e.g. '#ffffff'). Must be used with background_color. Only predefined Gmail colors are accepted."
+                            }
+                        },
+                        "required": ["name"]
+                    }
+                ),
+                Tool(
+                    name="modify_labels",
+                    description="Batch add/remove labels on emails. Accepts positions[] and/or message_ids[], plus add_labels[] and/or remove_labels[] (label names).",
+                    inputSchema={
+                        "type": "object",
+                        "properties": {
+                            "positions": {
+                                "type": "array",
+                                "items": {"type": "integer"},
+                                "description": "Position numbers from the email list"
+                            },
+                            "message_ids": {
+                                "type": "array",
+                                "items": {"type": "string"},
+                                "description": "Gmail message IDs"
+                            },
+                            "add_labels": {
+                                "type": "array",
+                                "items": {"type": "string"},
+                                "description": "Label names to add"
+                            },
+                            "remove_labels": {
+                                "type": "array",
+                                "items": {"type": "string"},
+                                "description": "Label names to remove"
+                            }
+                        }
+                    }
+                ),
+                Tool(
+                    name="list_recent_actions",
+                    description="Show recent actions taken on emails (delete, archive, label changes, etc.)",
+                    inputSchema={
+                        "type": "object",
+                        "properties": {
+                            "limit": {
+                                "type": "integer",
+                                "description": "Number of recent actions to show (default: 20)",
+                                "default": 20
+                            }
+                        }
+                    }
+                ),
             ]
-        
+
         @self.server.call_tool()
         async def handle_call_tool(name: str, arguments: dict[str, Any] | None) -> list[TextContent | ImageContent | EmbeddedResource]:
             """Handle tool calls."""
             if not self.gmail_client:
                 self.gmail_client = GmailClient()
-            
+
             try:
                 if name == "list_unread_emails":
                     subject_filter = arguments.get("subject_filter") if arguments else None
@@ -121,120 +233,183 @@ class GmailMCPServer:
                             )]
                         else:
                             raise
-                    
+
                     if not emails:
                         return [TextContent(
                             type="text",
                             text="No unread emails found matching the criteria."
                         )]
-                    
-                    # Format emails as simple numbered list - let AI handle categorization and analysis
+
                     formatted_output = self._format_email_list(emails)
-                    result = formatted_output
+                    return [TextContent(type="text", text=formatted_output)]
 
-                    return [TextContent(type="text", text=result)]
-                
-                elif name == "delete_email":
+                elif name == "delete_emails":
                     if not arguments:
-                        raise ValueError("Either message_id or position is required")
+                        raise ValueError("positions or message_ids required")
+                    ids = self._resolve_message_ids(arguments)
+                    results = self.gmail_client.delete_emails(ids)
+                    lines = []
+                    for r in results:
+                        if r['success']:
+                            self._record_action('delete', r.get('subject', ''), r['message_id'])
+                            lines.append(f"Deleted: {r.get('subject', 'Unknown Subject')}")
+                        else:
+                            lines.append(f"Failed to delete {r['message_id']}: {r['error']}")
+                    return [TextContent(type="text", text="\n".join(lines))]
 
-                    # Get message_id either directly or from position mapping
-                    message_id = arguments.get("message_id")
-                    position = arguments.get("position")
-
-                    if not message_id and not position:
-                        raise ValueError("Either message_id or position is required")
-
-                    if position and not message_id:
-                        if position not in self.email_position_map:
-                            raise ValueError(f"Position {position} not found in current email list. Please run 'list emails' first.")
-                        message_id = self.email_position_map[position]
-
-                    result = self.gmail_client.delete_email(message_id)
-
-                    if result["success"]:
-                        subject_text = f" - {result['subject']}" if result.get('subject') else ""
-                        return [TextContent(
-                            type="text",
-                            text=f"🗑️ Deleted: {result.get('subject', 'Unknown Subject')}"
-                        )]
-                    else:
-                        return [TextContent(
-                            type="text",
-                            text=f"Failed to move email with ID {message_id} to trash. Error: {result['error']}"
-                        )]
-                
-                elif name == "archive_email":
+                elif name == "archive_emails":
                     if not arguments:
-                        raise ValueError("Either message_id or position is required")
+                        raise ValueError("positions or message_ids required")
+                    ids = self._resolve_message_ids(arguments)
+                    results = self.gmail_client.archive_emails(ids)
+                    lines = []
+                    for r in results:
+                        if r['success']:
+                            self._record_action('archive', r.get('subject', ''), r['message_id'])
+                            lines.append(f"Archived: {r.get('subject', 'Unknown Subject')}")
+                        else:
+                            lines.append(f"Failed to archive {r['message_id']}: {r['error']}")
+                    return [TextContent(type="text", text="\n".join(lines))]
 
-                    # Get message_id either directly or from position mapping
-                    message_id = arguments.get("message_id")
-                    position = arguments.get("position")
+                elif name == "list_labels":
+                    labels = self.gmail_client.list_labels()
+                    lines = [f"{l['name']} (id: {l['id']}, type: {l['type']})" for l in labels]
+                    return [TextContent(type="text", text="\n".join(lines))]
 
-                    if not message_id and not position:
-                        raise ValueError("Either message_id or position is required")
+                elif name == "create_label":
+                    if not arguments or 'name' not in arguments:
+                        raise ValueError("name is required")
+                    result = self.gmail_client.create_label(
+                        arguments['name'],
+                        background_color=arguments.get('background_color'),
+                        text_color=arguments.get('text_color')
+                    )
+                    self._record_action('create_label', arguments['name'], '')
+                    return [TextContent(type="text", text=f"Created label: {result['name']} (id: {result['id']})")]
 
-                    if position and not message_id:
-                        if position not in self.email_position_map:
-                            raise ValueError(f"Position {position} not found in current email list. Please run 'list emails' first.")
-                        message_id = self.email_position_map[position]
+                elif name == "modify_labels":
+                    if not arguments:
+                        raise ValueError("positions or message_ids required, plus add_labels and/or remove_labels")
+                    ids = self._resolve_message_ids(arguments)
+                    add_labels = arguments.get('add_labels', [])
+                    remove_labels = arguments.get('remove_labels', [])
+                    results = self.gmail_client.modify_labels(ids, add_labels=add_labels, remove_labels=remove_labels)
+                    lines = []
+                    for r in results:
+                        if r['success']:
+                            self._record_action('modify_labels', f"+{add_labels} -{remove_labels}", r['message_id'])
+                            lines.append(f"Labels modified: {r['message_id']}")
+                        else:
+                            lines.append(f"Failed to modify labels {r['message_id']}: {r['error']}")
+                    return [TextContent(type="text", text="\n".join(lines))]
 
-                    result = self.gmail_client.archive_email(message_id)
+                elif name == "list_recent_actions":
+                    limit = (arguments or {}).get('limit', 20)
+                    actions = self.recent_actions[-limit:]
+                    if not actions:
+                        return [TextContent(type="text", text="No recent actions recorded.")]
+                    lines = []
+                    for a in actions:
+                        subj = f" - {a['subject']}" if a['subject'] else ""
+                        lines.append(f"[{a['timestamp']}] {a['action']}{subj}")
+                    return [TextContent(type="text", text="\n".join(lines))]
 
-                    if result["success"]:
-                        return [TextContent(
-                            type="text",
-                            text=f"📁 Archived: {result.get('subject', 'Unknown Subject')}"
-                        )]
-                    else:
-                        return [TextContent(
-                            type="text",
-                            text=f"Failed to archive email with ID {message_id}. Error: {result['error']}"
-                        )]
-                
                 else:
                     raise ValueError(f"Unknown tool: {name}")
-            
+
             except Exception as e:
                 return [TextContent(
                     type="text",
                     text=f"Error executing {name}: {str(e)}"
                 )]
 
-    def _format_email_list(self, emails: list) -> str:
-        """Format email list as simple numbered list with raw email data.
+    @staticmethod
+    def _clean_jira_body(body: str) -> str:
+        """Strip Jira email boilerplate and extract the actual comment content."""
+        lines = body.split('\n')
+        cleaned = []
+        skip_patterns = [
+            r'^\s*This message was sent by Atlassian Jira',
+            r'^\s*\[https?://.*jira.*\]',
+            r'^\s*-{3,}',
+            r'^\s*View this issue:',
+            r'^\s*You are receiving this',
+            r'^\s*If you think it was sent incorrectly',
+            r'^\s*Manage notifications',
+            r'^\s*\[jira\]',
+            r'^\s*For more information on JIRA',
+            r'^\s*This email.*confidential',
+        ]
+        for line in lines:
+            if any(re.search(p, line, re.IGNORECASE) for p in skip_patterns):
+                continue
+            cleaned.append(line)
 
-        All categorization, summarization, and priority analysis is handled by the AI model.
-        """
+        # Trim trailing blank lines
+        while cleaned and not cleaned[-1].strip():
+            cleaned.pop()
+        return '\n'.join(cleaned)
+
+    def _format_email_list(self, emails: list) -> str:
+        """Format email list with thread grouping and full body content."""
         if not emails:
             return "No unread emails found."
 
         # Clear previous position mapping
         self.email_position_map = {}
 
+        # Assign flat position numbers and build position map
+        for i, email in enumerate(emails, 1):
+            self.email_position_map[i] = email['id']
+            email['_position'] = i
+
+        # Resolve label IDs to names (fetch once)
+        try:
+            all_labels = {l['id']: l['name'] for l in self.gmail_client.list_labels()}
+        except Exception:
+            all_labels = {}
+
+        # Group by threadId
+        threads = OrderedDict()
+        for email in emails:
+            tid = email.get('threadId', email['id'])
+            threads.setdefault(tid, []).append(email)
+
         result = f"Found {len(emails)} unread emails:\n\n"
 
-        for i, email in enumerate(emails, 1):
-            # Store position to email ID mapping
-            self.email_position_map[i] = email['id']
+        for tid, thread_emails in threads.items():
+            # Thread header for multi-message threads
+            if len(thread_emails) > 1:
+                subject = thread_emails[0].get('subject', 'No Subject')
+                result += f"--- Thread: {subject} ({len(thread_emails)} messages) ---\n"
 
-            subject = email.get('subject', 'No Subject')
-            sender = email.get('sender', 'Unknown Sender')
-            date = email.get('date', 'Unknown Date')
-            body = email.get('body', '')
-            snippet = email.get('snippet', '')
+            for email in thread_emails:
+                pos = email['_position']
+                subject = email.get('subject', 'No Subject')
+                sender = email.get('sender', 'Unknown Sender')
+                date = email.get('date', 'Unknown Date')
+                body = email.get('body', '')
 
-            result += f"{i}: {subject}\n"
-            result += f"   From: {sender}\n"
-            result += f"   Date: {date}\n"
-            if snippet:
-                result += f"   Snippet: {snippet}\n"
-            if body and body != "No readable content":
-                # Limit body preview to first 200 characters
-                body_preview = body[:200] + "..." if len(body) > 200 else body
-                result += f"   Body: {body_preview}\n"
-            result += "\n"
+                # Resolve user labels (filter out standard ones)
+                user_labels = []
+                for lid in email.get('labelIds', []):
+                    if lid not in _HIDDEN_LABELS:
+                        label_name = all_labels.get(lid, lid)
+                        user_labels.append(label_name)
+
+                result += f"{pos}: {subject}\n"
+                result += f"   From: {sender}\n"
+                result += f"   Date: {date}\n"
+                if user_labels:
+                    result += f"   Labels: {', '.join(user_labels)}\n"
+
+                if body and body != "No readable content":
+                    # Check if this is a Jira email
+                    is_jira = bool(re.search(r'\[RH Jira\]|[A-Z]+-\d+', subject))
+                    if is_jira:
+                        body = self._clean_jira_body(body)
+                    result += f"   Body: {body}\n"
+                result += "\n"
 
         return result.rstrip()
 
@@ -246,7 +421,7 @@ class GmailMCPServer:
                 write_stream,
                 InitializationOptions(
                     server_name="gmail-mcp-server",
-                    server_version="0.1.0",
+                    server_version="0.2.0",
                     capabilities=self.server.get_capabilities(
                         notification_options=NotificationOptions(),
                         experimental_capabilities={}
@@ -258,10 +433,10 @@ class GmailMCPServer:
 def main():
     """Main entry point."""
     import argparse
-    
+
     parser = argparse.ArgumentParser(description="Gmail MCP Server")
     args = parser.parse_args()
-    
+
     server = GmailMCPServer()
     asyncio.run(server.run())
 

--- a/scripts/inbox-manager.sh
+++ b/scripts/inbox-manager.sh
@@ -1,0 +1,291 @@
+#!/usr/bin/env bash
+#
+# inbox-manager.sh - Autonomous inbox management via Claude Code
+#
+# Usage:
+#   ./scripts/inbox-manager.sh              # Run triage once
+#   ./scripts/inbox-manager.sh --watch      # Auto-reconcile every 10 minutes
+#   ./scripts/inbox-manager.sh --watch 15   # Auto-reconcile every 15 minutes
+#   ./scripts/inbox-manager.sh --help       # Show usage
+#
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+DEFAULT_INTERVAL=10
+DEFAULT_MODEL="haiku"
+LOG_DIR="$PROJECT_DIR/logs"
+
+# Dark orange (ANSI 256-color 208)
+C_ORANGE='\033[38;5;208m'
+C_DIM='\033[2m'
+C_RESET='\033[0m'
+C_GREEN='\033[32m'
+C_RED='\033[31m'
+
+SPINNER_CHARS='⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏'
+
+usage() {
+    cat <<'USAGE'
+inbox-manager.sh - Autonomous Gmail inbox management
+
+Usage:
+  inbox-manager.sh                  Run triage once (manual mode)
+  inbox-manager.sh --watch [MIN]    Auto-reconcile every MIN minutes (default: 10)
+  inbox-manager.sh --help           Show this help
+
+Options:
+  --watch [MIN]    Enable auto-reconcile mode. Runs triage on a loop.
+                   MIN = interval in minutes (default: 10, range: 5-60)
+  --max N          Max emails to process per run (default: 50)
+  --model MODEL    Claude model to use (default: haiku)
+                   Examples: haiku, sonnet, opus
+  --quiet          Suppress stdout, log to file only
+  --help           Show this help message
+
+Examples:
+  ./scripts/inbox-manager.sh                        # One-shot triage (haiku)
+  ./scripts/inbox-manager.sh --model opus           # Use Opus instead
+  ./scripts/inbox-manager.sh --watch                # Every 10 minutes
+  ./scripts/inbox-manager.sh --watch 15             # Every 15 minutes
+  ./scripts/inbox-manager.sh --watch --max 30       # Every 10 min, 30 emails max
+USAGE
+}
+
+format_elapsed() {
+    local secs=$1
+    local mins=$((secs / 60))
+    local s=$((secs % 60))
+    if [[ $mins -gt 0 ]]; then
+        printf "%dm%02ds" "$mins" "$s"
+    else
+        printf "%ds" "$s"
+    fi
+}
+
+spinner() {
+    # Usage: spinner <pid> <output_file>
+    # Shows a dark orange spinner with elapsed timer.
+    # Every 15s, verifies the background process is alive.
+    local pid=$1
+    local outfile=$2
+    local start_time=$SECONDS
+    local i=0
+    local last_check=0
+    local check_interval=15
+    local last_size=0
+
+    # Hide cursor
+    tput civis 2>/dev/null || true
+
+    while kill -0 "$pid" 2>/dev/null; do
+        local elapsed=$((SECONDS - start_time))
+        local elapsed_fmt
+        elapsed_fmt=$(format_elapsed $elapsed)
+
+        # Spinner character
+        local char="${SPINNER_CHARS:i%${#SPINNER_CHARS}:1}"
+        i=$((i + 1))
+
+        # Every 15s, check process health + output file growth
+        local status_msg=""
+        local since_check=$((elapsed - last_check))
+        if [[ $since_check -ge $check_interval ]]; then
+            last_check=$elapsed
+            if kill -0 "$pid" 2>/dev/null; then
+                # Check if output file is growing (claude is producing output)
+                local cur_size
+                cur_size=$(stat -c%s "$outfile" 2>/dev/null || echo 0)
+                if [[ $cur_size -gt $last_size ]]; then
+                    status_msg=" — processing"
+                    last_size=$cur_size
+                else
+                    # Process alive but no new output — still thinking
+                    status_msg=" — thinking"
+                fi
+            fi
+        fi
+
+        printf "\r${C_ORANGE}%s${C_RESET} Triaging inbox... ${C_DIM}%s${C_RESET}  ${C_DIM}pid:%s${C_RESET}%s  " \
+            "$char" "$elapsed_fmt" "$pid" "$status_msg"
+
+        sleep 0.1
+    done
+
+    # Clear spinner line
+    printf "\r\033[K"
+
+    # Restore cursor
+    tput cnorm 2>/dev/null || true
+}
+
+run_triage() {
+    local max_emails="${1:-50}"
+    local model="${2:-$DEFAULT_MODEL}"
+    local timestamp
+    timestamp="$(date '+%Y-%m-%d %H:%M:%S')"
+
+    echo -e "${C_ORANGE}[$timestamp]${C_RESET} Running inbox triage (max: $max_emails emails, model: $model)..."
+
+    cd "$PROJECT_DIR"
+
+    # MCP tools are prefixed with mcp__gmail__ in Claude's tool registry
+    local allowed_tools="mcp__gmail__list_unread_emails"
+    allowed_tools+=",mcp__gmail__delete_emails"
+    allowed_tools+=",mcp__gmail__archive_emails"
+    allowed_tools+=",mcp__gmail__modify_labels"
+    allowed_tools+=",mcp__gmail__list_labels"
+    allowed_tools+=",mcp__gmail__create_label"
+    allowed_tools+=",mcp__gmail__list_recent_actions"
+
+    # Run claude in background, capture output to temp file
+    local tmpfile
+    tmpfile=$(mktemp /tmp/triage-output.XXXXXX)
+
+    local start_time=$SECONDS
+    local claude_pid=""
+
+    # Cleanup handler: kill claude, restore cursor, remove tmpfile
+    cleanup() {
+        if [[ -n "$claude_pid" ]] && kill -0 "$claude_pid" 2>/dev/null; then
+            kill -TERM "$claude_pid" 2>/dev/null
+            wait "$claude_pid" 2>/dev/null || true
+        fi
+        tput cnorm 2>/dev/null || true
+        printf "\r\033[K"
+        rm -f "$tmpfile"
+        echo ""
+        echo -e "${C_RED}Triage aborted.${C_RESET}"
+        exit 130
+    }
+    trap cleanup INT TERM
+
+    CLAUDECODE= claude -p "/triage $max_emails" \
+        --model "$model" \
+        --allowedTools "$allowed_tools" \
+        --output-format json \
+        > "$tmpfile" 2>/dev/null &
+    claude_pid=$!
+
+    # Show spinner while claude runs
+    spinner "$claude_pid" "$tmpfile"
+
+    # Wait for claude to finish and get exit code
+    local exit_code=0
+    wait "$claude_pid" || exit_code=$?
+    claude_pid=""  # Clear so cleanup doesn't try to kill again
+
+    # Restore default signal handling and clean tmpfile on return
+    trap - INT TERM
+    trap "rm -f '$tmpfile'" RETURN
+
+    local elapsed=$((SECONDS - start_time))
+    local elapsed_fmt
+    elapsed_fmt=$(format_elapsed $elapsed)
+
+    local raw_output
+    raw_output=$(cat "$tmpfile")
+
+    # Extract the result text and cost from JSON output
+    # Try multiple field names for cost (API may vary)
+    local result cost_usd
+    result=$(echo "$raw_output" | jq -r '.result // empty' 2>/dev/null)
+    cost_usd=$(echo "$raw_output" | jq -r '.total_cost_usd | select(. != null) | tostring' 2>/dev/null)
+
+    if [[ -n "$result" ]]; then
+        echo "$result"
+    else
+        # Fallback: JSON parsing failed, show raw output
+        echo "$raw_output"
+    fi
+
+    echo ""
+    local cost_str=""
+    if [[ -n "$cost_usd" ]]; then
+        cost_str=" | Cost: \$${cost_usd}"
+    fi
+
+    if [[ $exit_code -eq 0 ]]; then
+        echo -e "${C_GREEN}[$timestamp]${C_RESET} Triage complete in ${elapsed_fmt}${cost_str}"
+    else
+        echo -e "${C_RED}[$timestamp]${C_RESET} Triage failed (exit $exit_code) after ${elapsed_fmt}${cost_str}"
+    fi
+}
+
+main() {
+    local watch=false
+    local interval=$DEFAULT_INTERVAL
+    local max_emails=100
+    local model=$DEFAULT_MODEL
+    local quiet=false
+
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --watch)
+                watch=true
+                # Check if next arg is a number (interval)
+                if [[ "${2:-}" =~ ^[0-9]+$ ]]; then
+                    interval="$2"
+                    shift
+                fi
+                shift
+                ;;
+            --max)
+                max_emails="${2:?--max requires a number}"
+                shift 2
+                ;;
+            --model)
+                model="${2:?--model requires a value (e.g. haiku, sonnet, opus)}"
+                shift 2
+                ;;
+            --quiet)
+                quiet=true
+                shift
+                ;;
+            --help|-h)
+                usage
+                exit 0
+                ;;
+            *)
+                echo "Unknown option: $1"
+                usage
+                exit 1
+                ;;
+        esac
+    done
+
+    # Validate interval
+    if [[ "$interval" -lt 5 || "$interval" -gt 60 ]]; then
+        echo "Error: interval must be between 5 and 60 minutes (got: $interval)"
+        exit 1
+    fi
+
+    if $watch; then
+        echo "Inbox Manager: auto-reconcile mode (every ${interval}m, max ${max_emails} emails, model: ${model})"
+        echo "Press Ctrl+C to stop."
+        echo ""
+
+        # Set up log directory for watch mode
+        mkdir -p "$LOG_DIR"
+        local logfile="$LOG_DIR/triage-$(date '+%Y%m%d').log"
+
+        trap 'echo ""; echo "Inbox Manager stopped."; exit 0' INT TERM
+
+        while true; do
+            if $quiet; then
+                run_triage "$max_emails" "$model" >> "$logfile" 2>&1
+            else
+                run_triage "$max_emails" "$model" 2>&1 | tee -a "$logfile"
+            fi
+
+            echo "Next run in ${interval} minutes... (Ctrl+C to stop)"
+            sleep "$((interval * 60))"
+        done
+    else
+        # One-shot mode
+        run_triage "$max_emails" "$model"
+    fi
+}
+
+main "$@"

--- a/tests/test_gmail_client.py
+++ b/tests/test_gmail_client.py
@@ -1,0 +1,299 @@
+"""Tests for GmailClient - gmail_client.py logic."""
+
+import base64
+import pytest
+from unittest.mock import MagicMock, patch, PropertyMock
+
+from gmail_mcp_server.gmail_client import GmailClient
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_client():
+    """Create a GmailClient with mocked auth and service."""
+    with patch.object(GmailClient, '_authenticate'):
+        client = GmailClient()
+    client._authenticated = True
+    client.service = MagicMock()
+    return client
+
+
+def _b64(text):
+    """Base64url-encode a string the way Gmail API does."""
+    return base64.urlsafe_b64encode(text.encode('utf-8')).decode('utf-8')
+
+
+def _make_gmail_message(message_id, subject="Test", sender="a@b.com",
+                        body_text="Hello", thread_id=None, label_ids=None):
+    """Build a fake Gmail API message response."""
+    return {
+        'id': message_id,
+        'threadId': thread_id or message_id,
+        'labelIds': label_ids or ['INBOX', 'UNREAD'],
+        'snippet': body_text[:40],
+        'payload': {
+            'mimeType': 'multipart/alternative',
+            'headers': [
+                {'name': 'Subject', 'value': subject},
+                {'name': 'From', 'value': sender},
+                {'name': 'Date', 'value': 'Mon, 1 Jan 2024 00:00:00 +0000'},
+            ],
+            'parts': [
+                {
+                    'mimeType': 'text/plain',
+                    'body': {'data': _b64(body_text)},
+                },
+            ],
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# _get_email_details
+# ---------------------------------------------------------------------------
+
+class TestGetEmailDetails:
+    def test_returns_threadid_and_labelids(self):
+        client = _make_client()
+        msg = _make_gmail_message('m1', thread_id='t1', label_ids=['INBOX', 'UNREAD', 'Label_1'])
+        client.service.users().messages().get().execute.return_value = msg
+        result = client._get_email_details('m1')
+        assert result['threadId'] == 't1'
+        assert result['labelIds'] == ['INBOX', 'UNREAD', 'Label_1']
+
+    def test_extracts_subject_sender_date(self):
+        client = _make_client()
+        msg = _make_gmail_message('m1', subject='Hello World', sender='test@example.com')
+        client.service.users().messages().get().execute.return_value = msg
+        result = client._get_email_details('m1')
+        assert result['subject'] == 'Hello World'
+        assert result['sender'] == 'test@example.com'
+        assert result['date'] == 'Mon, 1 Jan 2024 00:00:00 +0000'
+
+    def test_extracts_body(self):
+        client = _make_client()
+        msg = _make_gmail_message('m1', body_text='Body content here')
+        client.service.users().messages().get().execute.return_value = msg
+        result = client._get_email_details('m1')
+        assert result['body'] == 'Body content here'
+
+    def test_missing_headers_defaults(self):
+        client = _make_client()
+        msg = _make_gmail_message('m1')
+        msg['payload']['headers'] = []  # no headers at all
+        client.service.users().messages().get().execute.return_value = msg
+        result = client._get_email_details('m1')
+        assert result['subject'] == 'No Subject'
+        assert result['sender'] == 'Unknown Sender'
+        assert result['date'] == 'Unknown Date'
+
+
+# ---------------------------------------------------------------------------
+# _extract_email_body
+# ---------------------------------------------------------------------------
+
+class TestExtractEmailBody:
+    def setup_method(self):
+        self.client = _make_client()
+
+    def test_plain_text_part(self):
+        payload = {
+            'mimeType': 'multipart/alternative',
+            'parts': [
+                {'mimeType': 'text/plain', 'body': {'data': _b64('Plain text')}},
+                {'mimeType': 'text/html', 'body': {'data': _b64('<b>HTML</b>')}},
+            ]
+        }
+        assert self.client._extract_email_body(payload) == 'Plain text'
+
+    def test_html_fallback(self):
+        payload = {
+            'mimeType': 'multipart/alternative',
+            'parts': [
+                {'mimeType': 'text/plain', 'body': {'data': ''}},
+                {'mimeType': 'text/html', 'body': {'data': _b64('<b>HTML</b>')}},
+            ]
+        }
+        assert self.client._extract_email_body(payload) == '<b>HTML</b>'
+
+    def test_single_part_plain(self):
+        payload = {
+            'mimeType': 'text/plain',
+            'body': {'data': _b64('Single part')},
+        }
+        assert self.client._extract_email_body(payload) == 'Single part'
+
+    def test_no_content(self):
+        payload = {
+            'mimeType': 'text/plain',
+            'body': {'data': ''},
+        }
+        assert self.client._extract_email_body(payload) == 'No readable content'
+
+
+# ---------------------------------------------------------------------------
+# delete_emails / delete_email
+# ---------------------------------------------------------------------------
+
+class TestDeleteEmails:
+    def setup_method(self):
+        self.client = _make_client()
+
+    def test_single_delete(self):
+        msg = _make_gmail_message('m1', subject='Delete me')
+        self.client.service.users().messages().get().execute.return_value = msg
+        self.client.service.users().messages().modify().execute.return_value = {}
+
+        results = self.client.delete_emails(['m1'])
+        assert len(results) == 1
+        assert results[0]['success'] is True
+        assert results[0]['subject'] == 'Delete me'
+        assert results[0]['message_id'] == 'm1'
+
+    def test_batch_delete(self):
+        msg = _make_gmail_message('m1', subject='A')
+        self.client.service.users().messages().get().execute.return_value = msg
+        self.client.service.users().messages().modify().execute.return_value = {}
+
+        results = self.client.delete_emails(['m1', 'm2', 'm3'])
+        assert len(results) == 3
+        assert all(r['success'] for r in results)
+
+    def test_delete_email_wrapper(self):
+        msg = _make_gmail_message('m1', subject='Wrapper test')
+        self.client.service.users().messages().get().execute.return_value = msg
+        self.client.service.users().messages().modify().execute.return_value = {}
+
+        result = self.client.delete_email('m1')
+        assert result['success'] is True
+
+    def test_long_subject_truncated(self):
+        long_subject = "A" * 70
+        msg = _make_gmail_message('m1', subject=long_subject)
+        self.client.service.users().messages().get().execute.return_value = msg
+        self.client.service.users().messages().modify().execute.return_value = {}
+
+        result = self.client.delete_emails(['m1'])
+        assert len(result[0]['subject']) == 60
+        assert result[0]['subject'].endswith("...")
+
+
+# ---------------------------------------------------------------------------
+# archive_emails / archive_email
+# ---------------------------------------------------------------------------
+
+class TestArchiveEmails:
+    def setup_method(self):
+        self.client = _make_client()
+
+    def test_single_archive(self):
+        msg = _make_gmail_message('m1', subject='Archive me')
+        self.client.service.users().messages().get().execute.return_value = msg
+        self.client.service.users().messages().modify().execute.return_value = {}
+
+        results = self.client.archive_emails(['m1'])
+        assert len(results) == 1
+        assert results[0]['success'] is True
+
+    def test_archive_email_wrapper(self):
+        msg = _make_gmail_message('m1', subject='Wrapper')
+        self.client.service.users().messages().get().execute.return_value = msg
+        self.client.service.users().messages().modify().execute.return_value = {}
+
+        result = self.client.archive_email('m1')
+        assert result['success'] is True
+
+
+# ---------------------------------------------------------------------------
+# list_labels / create_label / _resolve_label_name_to_id
+# ---------------------------------------------------------------------------
+
+class TestLabels:
+    def setup_method(self):
+        self.client = _make_client()
+
+    def test_list_labels(self):
+        self.client.service.users().labels().list().execute.return_value = {
+            'labels': [
+                {'id': 'L1', 'name': 'INBOX', 'type': 'system'},
+                {'id': 'L2', 'name': 'Triage/Jira', 'type': 'user'},
+            ]
+        }
+        result = self.client.list_labels()
+        assert len(result) == 2
+        assert result[1]['name'] == 'Triage/Jira'
+        assert result[1]['id'] == 'L2'
+
+    def test_create_label(self):
+        self.client.service.users().labels().create().execute.return_value = {
+            'id': 'L3', 'name': 'Triage/New'
+        }
+        result = self.client.create_label('Triage/New')
+        assert result == {'id': 'L3', 'name': 'Triage/New'}
+
+    def test_resolve_label_name_to_id(self):
+        self.client.service.users().labels().list().execute.return_value = {
+            'labels': [
+                {'id': 'L1', 'name': 'INBOX', 'type': 'system'},
+                {'id': 'L2', 'name': 'Triage/Jira', 'type': 'user'},
+            ]
+        }
+        assert self.client._resolve_label_name_to_id('Triage/Jira') == 'L2'
+        assert self.client._resolve_label_name_to_id('triage/jira') == 'L2'  # case insensitive
+
+    def test_resolve_label_not_found(self):
+        self.client.service.users().labels().list().execute.return_value = {
+            'labels': [{'id': 'L1', 'name': 'INBOX', 'type': 'system'}]
+        }
+        with pytest.raises(ValueError, match="Label not found"):
+            self.client._resolve_label_name_to_id('Nonexistent')
+
+
+# ---------------------------------------------------------------------------
+# modify_labels
+# ---------------------------------------------------------------------------
+
+class TestModifyLabels:
+    def setup_method(self):
+        self.client = _make_client()
+        self.client.service.users().labels().list().execute.return_value = {
+            'labels': [
+                {'id': 'L1', 'name': 'Triage/Jira', 'type': 'user'},
+                {'id': 'L2', 'name': 'Triage/Security', 'type': 'user'},
+            ]
+        }
+
+    def test_add_labels(self):
+        self.client.service.users().messages().modify().execute.return_value = {}
+        results = self.client.modify_labels(['m1'], add_labels=['Triage/Jira'])
+        assert len(results) == 1
+        assert results[0]['success'] is True
+
+    def test_add_and_remove(self):
+        self.client.service.users().messages().modify().execute.return_value = {}
+        results = self.client.modify_labels(
+            ['m1', 'm2'],
+            add_labels=['Triage/Jira'],
+            remove_labels=['Triage/Security']
+        )
+        assert len(results) == 2
+        assert all(r['success'] for r in results)
+
+    def test_label_not_found_raises(self):
+        with pytest.raises(ValueError, match="Label not found"):
+            self.client.modify_labels(['m1'], add_labels=['Nonexistent'])
+
+
+# ---------------------------------------------------------------------------
+# mark_as_read
+# ---------------------------------------------------------------------------
+
+class TestMarkAsRead:
+    def test_batch_mark_as_read(self):
+        client = _make_client()
+        client.service.users().messages().modify().execute.return_value = {}
+        results = client.mark_as_read(['m1', 'm2'])
+        assert len(results) == 2
+        assert all(r['success'] for r in results)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,0 +1,474 @@
+"""Tests for GmailMCPServer - server.py logic."""
+
+import asyncio
+import base64
+import pytest
+from unittest.mock import MagicMock, patch, AsyncMock
+
+import mcp.types as mcp_types
+from gmail_mcp_server.server import GmailMCPServer, _HIDDEN_LABELS
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_email(id, subject, sender="alice@example.com", thread_id=None,
+                label_ids=None, body="Hello world", date="Mon, 1 Jan 2024"):
+    """Build an email dict matching what gmail_client returns."""
+    return {
+        'id': id,
+        'threadId': thread_id or id,
+        'labelIds': label_ids or ['INBOX', 'UNREAD'],
+        'subject': subject,
+        'sender': sender,
+        'date': date,
+        'body': body,
+        'snippet': body[:40],
+    }
+
+
+def _text(result):
+    """Extract the text string from a tool-call result list."""
+    return result[0].text
+
+
+def _call_tool_sync(srv, name, arguments=None):
+    """Call a tool handler on the MCP server synchronously."""
+    req = mcp_types.CallToolRequest(
+        method='tools/call',
+        params=mcp_types.CallToolRequestParams(name=name, arguments=arguments or {}),
+    )
+    handler = srv.server.request_handlers[mcp_types.CallToolRequest]
+    resp = asyncio.get_event_loop().run_until_complete(handler(req))
+    # ServerResult wraps the actual result in .root
+    return resp.root if hasattr(resp, 'root') else resp
+
+
+def _list_tools_sync(srv):
+    """List tools from the MCP server synchronously."""
+    req = mcp_types.ListToolsRequest(method='tools/list')
+    handler = srv.server.request_handlers[mcp_types.ListToolsRequest]
+    resp = asyncio.get_event_loop().run_until_complete(handler(req))
+    return resp.root if hasattr(resp, 'root') else resp
+
+
+# ---------------------------------------------------------------------------
+# _record_action
+# ---------------------------------------------------------------------------
+
+class TestRecordAction:
+    def test_appends_action(self):
+        srv = GmailMCPServer()
+        srv._record_action('delete', 'Test Subject', 'msg-1')
+        assert len(srv.recent_actions) == 1
+        a = srv.recent_actions[0]
+        assert a['action'] == 'delete'
+        assert a['subject'] == 'Test Subject'
+        assert a['message_id'] == 'msg-1'
+        assert 'timestamp' in a
+
+    def test_caps_at_100(self):
+        srv = GmailMCPServer()
+        for i in range(110):
+            srv._record_action('archive', f'Subj {i}', f'msg-{i}')
+        assert len(srv.recent_actions) == 100
+        assert srv.recent_actions[0]['subject'] == 'Subj 10'
+        assert srv.recent_actions[-1]['subject'] == 'Subj 109'
+
+
+# ---------------------------------------------------------------------------
+# _resolve_message_ids
+# ---------------------------------------------------------------------------
+
+class TestResolveMessageIds:
+    def setup_method(self):
+        self.srv = GmailMCPServer()
+        self.srv.email_position_map = {1: 'id-a', 2: 'id-b', 3: 'id-c'}
+
+    def test_resolves_positions(self):
+        ids = self.srv._resolve_message_ids({'positions': [1, 3]})
+        assert ids == ['id-a', 'id-c']
+
+    def test_resolves_message_ids_directly(self):
+        ids = self.srv._resolve_message_ids({'message_ids': ['id-x', 'id-y']})
+        assert ids == ['id-x', 'id-y']
+
+    def test_combines_both(self):
+        ids = self.srv._resolve_message_ids({
+            'positions': [2],
+            'message_ids': ['id-x']
+        })
+        assert set(ids) == {'id-x', 'id-b'}
+
+    def test_fallback_single_position(self):
+        ids = self.srv._resolve_message_ids({'position': 1})
+        assert ids == ['id-a']
+
+    def test_fallback_single_message_id(self):
+        ids = self.srv._resolve_message_ids({'message_id': 'id-z'})
+        assert ids == ['id-z']
+
+    def test_invalid_position_raises(self):
+        with pytest.raises(ValueError, match="Position 99"):
+            self.srv._resolve_message_ids({'positions': [99]})
+
+    def test_invalid_fallback_position_raises(self):
+        with pytest.raises(ValueError, match="Position 99"):
+            self.srv._resolve_message_ids({'position': 99})
+
+    def test_empty_raises(self):
+        with pytest.raises(ValueError, match="No message IDs"):
+            self.srv._resolve_message_ids({})
+
+    def test_none_lists_raises(self):
+        with pytest.raises(ValueError, match="No message IDs"):
+            self.srv._resolve_message_ids({'positions': None, 'message_ids': None})
+
+
+# ---------------------------------------------------------------------------
+# _clean_jira_body
+# ---------------------------------------------------------------------------
+
+class TestCleanJiraBody:
+    def test_strips_boilerplate(self):
+        body = (
+            "John Smith commented:\n"
+            "This is the actual comment.\n"
+            "\n"
+            "---\n"
+            "This message was sent by Atlassian Jira\n"
+            "View this issue: https://issues.redhat.com/browse/ACM-123\n"
+            "You are receiving this because you are subscribed.\n"
+            "Manage notifications: https://issues.redhat.com/preferences\n"
+        )
+        cleaned = GmailMCPServer._clean_jira_body(body)
+        assert "John Smith commented:" in cleaned
+        assert "This is the actual comment." in cleaned
+        assert "Atlassian Jira" not in cleaned
+        assert "View this issue" not in cleaned
+        assert "You are receiving this" not in cleaned
+        assert "Manage notifications" not in cleaned
+        assert "---" not in cleaned
+
+    def test_preserves_normal_content(self):
+        body = "Just a normal comment\nwith multiple lines."
+        cleaned = GmailMCPServer._clean_jira_body(body)
+        assert cleaned == body
+
+    def test_strips_trailing_blanks(self):
+        body = "Content here\n\n\n\n"
+        cleaned = GmailMCPServer._clean_jira_body(body)
+        assert cleaned == "Content here"
+
+    def test_handles_empty_body(self):
+        assert GmailMCPServer._clean_jira_body("") == ""
+
+    def test_strips_jira_link_lines(self):
+        body = (
+            "Comment text\n"
+            "[https://issues.redhat.com/jira/browse/ACM-100]\n"
+            "[jira] notification footer\n"
+            "For more information on JIRA, see docs.\n"
+        )
+        cleaned = GmailMCPServer._clean_jira_body(body)
+        assert cleaned == "Comment text"
+
+    def test_case_insensitive_matching(self):
+        body = "content\nTHIS MESSAGE WAS SENT BY ATLASSIAN JIRA\nmore content"
+        cleaned = GmailMCPServer._clean_jira_body(body)
+        assert "ATLASSIAN JIRA" not in cleaned
+        assert "content" in cleaned
+        assert "more content" in cleaned
+
+
+# ---------------------------------------------------------------------------
+# _format_email_list
+# ---------------------------------------------------------------------------
+
+class TestFormatEmailList:
+    def setup_method(self):
+        self.srv = GmailMCPServer()
+        self.srv.gmail_client = MagicMock()
+        self.srv.gmail_client.list_labels.return_value = [
+            {'id': 'Label_1', 'name': 'Triage/Jira', 'type': 'user'},
+            {'id': 'Label_2', 'name': 'Triage/Security', 'type': 'user'},
+        ]
+
+    def test_empty_list(self):
+        assert self.srv._format_email_list([]) == "No unread emails found."
+
+    def test_single_email_basic(self):
+        emails = [_make_email('m1', 'Test Subject')]
+        output = self.srv._format_email_list(emails)
+        assert "Found 1 unread emails" in output
+        assert "1: Test Subject" in output
+        assert "From: alice@example.com" in output
+        assert "Body: Hello world" in output
+
+    def test_position_map_built(self):
+        emails = [_make_email('m1', 'A'), _make_email('m2', 'B')]
+        self.srv._format_email_list(emails)
+        assert self.srv.email_position_map == {1: 'm1', 2: 'm2'}
+
+    def test_thread_grouping_header(self):
+        emails = [
+            _make_email('m1', 'Thread Subject', thread_id='t1'),
+            _make_email('m2', 'Re: Thread Subject', thread_id='t1'),
+        ]
+        output = self.srv._format_email_list(emails)
+        assert "--- Thread: Thread Subject (2 messages) ---" in output
+        assert "1: Thread Subject" in output
+        assert "2: Re: Thread Subject" in output
+
+    def test_no_thread_header_for_single(self):
+        emails = [_make_email('m1', 'Solo Email', thread_id='t1')]
+        output = self.srv._format_email_list(emails)
+        assert "--- Thread:" not in output
+
+    def test_user_labels_shown(self):
+        emails = [_make_email('m1', 'Labeled', label_ids=['INBOX', 'UNREAD', 'Label_1'])]
+        output = self.srv._format_email_list(emails)
+        assert "Labels: Triage/Jira" in output
+
+    def test_hidden_labels_filtered(self):
+        emails = [_make_email('m1', 'X', label_ids=['INBOX', 'UNREAD', 'SPAM', 'IMPORTANT'])]
+        output = self.srv._format_email_list(emails)
+        assert "Labels:" not in output
+
+    def test_full_body_not_truncated(self):
+        long_body = "A" * 500
+        emails = [_make_email('m1', 'Long', body=long_body)]
+        output = self.srv._format_email_list(emails)
+        assert long_body in output
+        assert "..." not in output
+
+    def test_jira_body_cleaned(self):
+        jira_body = (
+            "Real comment\n"
+            "---\n"
+            "This message was sent by Atlassian Jira\n"
+        )
+        emails = [_make_email('m1', '[RH Jira] ACM-123 update', body=jira_body)]
+        output = self.srv._format_email_list(emails)
+        assert "Real comment" in output
+        assert "Atlassian Jira" not in output
+
+    def test_jira_detected_by_ticket_pattern(self):
+        jira_body = "Comment\n---\nThis message was sent by Atlassian Jira\n"
+        emails = [_make_email('m1', 'ACM-456 something broke', body=jira_body)]
+        output = self.srv._format_email_list(emails)
+        assert "Atlassian Jira" not in output
+
+    def test_non_jira_body_not_cleaned(self):
+        body = "Some text\nA normal separator line\nMore content"
+        emails = [_make_email('m1', 'Regular email', body=body)]
+        output = self.srv._format_email_list(emails)
+        assert "Some text" in output
+        assert "A normal separator line" in output
+        assert "More content" in output
+
+    def test_no_readable_content_hidden(self):
+        emails = [_make_email('m1', 'Empty', body='No readable content')]
+        output = self.srv._format_email_list(emails)
+        assert "Body:" not in output
+
+    def test_label_fetch_failure_graceful(self):
+        self.srv.gmail_client.list_labels.side_effect = Exception("API error")
+        emails = [_make_email('m1', 'Test', label_ids=['Label_1'])]
+        output = self.srv._format_email_list(emails)
+        assert "Labels: Label_1" in output
+
+    def test_multiple_threads(self):
+        emails = [
+            _make_email('m1', 'Thread A msg 1', thread_id='t1'),
+            _make_email('m2', 'Thread A msg 2', thread_id='t1'),
+            _make_email('m3', 'Solo email', thread_id='t2'),
+            _make_email('m4', 'Thread B msg 1', thread_id='t3'),
+            _make_email('m5', 'Thread B msg 2', thread_id='t3'),
+        ]
+        output = self.srv._format_email_list(emails)
+        assert "--- Thread: Thread A msg 1 (2 messages) ---" in output
+        assert "--- Thread: Thread B msg 1 (2 messages) ---" in output
+        assert output.count("--- Thread:") == 2
+        for i in range(1, 6):
+            assert f"{i}:" in output
+
+
+# ---------------------------------------------------------------------------
+# Tool handlers (async, via MCP request objects)
+# ---------------------------------------------------------------------------
+
+class TestToolHandlers:
+    """Test the tool handlers via the MCP request_handlers interface."""
+
+    def setup_method(self):
+        self.srv = GmailMCPServer()
+        self.srv.gmail_client = MagicMock()
+        self.srv.email_position_map = {1: 'id-a', 2: 'id-b', 3: 'id-c'}
+
+    def _call(self, name, arguments=None):
+        resp = _call_tool_sync(self.srv, name, arguments)
+        return resp.content
+
+    def test_delete_emails_by_positions(self):
+        self.srv.gmail_client.delete_emails.return_value = [
+            {'success': True, 'subject': 'Test', 'message_id': 'id-a', 'error': None},
+            {'success': True, 'subject': 'Test2', 'message_id': 'id-b', 'error': None},
+        ]
+        result = self._call('delete_emails', {'positions': [1, 2]})
+        text = _text(result)
+        assert "Deleted: Test" in text
+        assert "Deleted: Test2" in text
+        self.srv.gmail_client.delete_emails.assert_called_once_with(['id-a', 'id-b'])
+        assert len(self.srv.recent_actions) == 2
+
+    def test_delete_emails_failure(self):
+        self.srv.gmail_client.delete_emails.return_value = [
+            {'success': False, 'subject': None, 'message_id': 'id-a', 'error': 'HTTP 404'},
+        ]
+        result = self._call('delete_emails', {'message_ids': ['id-a']})
+        text = _text(result)
+        assert "Failed to delete id-a" in text
+        assert "HTTP 404" in text
+        assert len(self.srv.recent_actions) == 0
+
+    def test_archive_emails_by_positions(self):
+        self.srv.gmail_client.archive_emails.return_value = [
+            {'success': True, 'subject': 'Archived Subj', 'message_id': 'id-c', 'error': None},
+        ]
+        result = self._call('archive_emails', {'positions': [3]})
+        text = _text(result)
+        assert "Archived: Archived Subj" in text
+        assert len(self.srv.recent_actions) == 1
+        assert self.srv.recent_actions[0]['action'] == 'archive'
+
+    def test_list_labels(self):
+        self.srv.gmail_client.list_labels.return_value = [
+            {'id': 'L1', 'name': 'Triage/Jira', 'type': 'user'},
+            {'id': 'L2', 'name': 'INBOX', 'type': 'system'},
+        ]
+        result = self._call('list_labels', {})
+        text = _text(result)
+        assert "Triage/Jira" in text
+        assert "INBOX" in text
+
+    def test_create_label(self):
+        self.srv.gmail_client.create_label.return_value = {'id': 'L3', 'name': 'Triage/New'}
+        result = self._call('create_label', {'name': 'Triage/New'})
+        text = _text(result)
+        assert "Created label: Triage/New" in text
+        assert "L3" in text
+        assert len(self.srv.recent_actions) == 1
+        assert self.srv.recent_actions[0]['action'] == 'create_label'
+
+    def test_create_label_missing_name(self):
+        result = self._call('create_label', {})
+        text = _text(result)
+        # MCP framework validates required fields before handler runs
+        assert "required" in text.lower() or "name" in text.lower()
+
+    def test_modify_labels(self):
+        self.srv.gmail_client.modify_labels.return_value = [
+            {'success': True, 'message_id': 'id-a', 'error': None},
+        ]
+        result = self._call('modify_labels', {
+            'positions': [1],
+            'add_labels': ['Triage/Jira'],
+            'remove_labels': [],
+        })
+        text = _text(result)
+        assert "Labels modified: id-a" in text
+        self.srv.gmail_client.modify_labels.assert_called_once_with(
+            ['id-a'], add_labels=['Triage/Jira'], remove_labels=[]
+        )
+
+    def test_list_recent_actions_empty(self):
+        result = self._call('list_recent_actions', {})
+        text = _text(result)
+        assert "No recent actions" in text
+
+    def test_list_recent_actions_with_data(self):
+        self.srv._record_action('delete', 'Subj A', 'msg-1')
+        self.srv._record_action('archive', 'Subj B', 'msg-2')
+        result = self._call('list_recent_actions', {'limit': 10})
+        text = _text(result)
+        assert "delete" in text
+        assert "Subj A" in text
+        assert "archive" in text
+        assert "Subj B" in text
+
+    def test_list_recent_actions_respects_limit(self):
+        for i in range(10):
+            self.srv._record_action('delete', f'Subj {i}', f'msg-{i}')
+        result = self._call('list_recent_actions', {'limit': 3})
+        text = _text(result)
+        lines = [l for l in text.strip().split('\n') if l.strip()]
+        assert len(lines) == 3
+
+    def test_unknown_tool(self):
+        result = self._call('nonexistent_tool', {})
+        text = _text(result)
+        assert "Error" in text
+        assert "Unknown tool" in text
+
+    def test_delete_emails_no_args(self):
+        result = self._call('delete_emails')
+        text = _text(result)
+        assert "Error" in text
+
+    def test_list_unread_emails_no_results(self):
+        self.srv.gmail_client.list_unread_emails.return_value = []
+        result = self._call('list_unread_emails', {})
+        text = _text(result)
+        assert "No unread emails" in text
+
+    def test_list_unread_emails_auth_error(self):
+        self.srv.gmail_client.list_unread_emails.side_effect = Exception(
+            "Authentication required but no valid token found"
+        )
+        result = self._call('list_unread_emails', {})
+        text = _text(result)
+        assert "authentication" in text.lower()
+
+
+# ---------------------------------------------------------------------------
+# Tool listing
+# ---------------------------------------------------------------------------
+
+class TestListTools:
+    def test_expected_tools_registered(self):
+        srv = GmailMCPServer()
+        resp = _list_tools_sync(srv)
+        names = {t.name for t in resp.tools}
+        expected = {
+            'list_unread_emails', 'delete_emails', 'archive_emails',
+            'list_labels', 'create_label', 'modify_labels',
+            'list_recent_actions',
+        }
+        assert names == expected
+
+    def test_no_mark_as_read_tool(self):
+        srv = GmailMCPServer()
+        resp = _list_tools_sync(srv)
+        names = {t.name for t in resp.tools}
+        assert 'mark_as_read' not in names
+
+    def test_seven_tools_total(self):
+        srv = GmailMCPServer()
+        resp = _list_tools_sync(srv)
+        assert len(resp.tools) == 7
+
+
+# ---------------------------------------------------------------------------
+# _HIDDEN_LABELS
+# ---------------------------------------------------------------------------
+
+class TestHiddenLabels:
+    def test_standard_labels_hidden(self):
+        for label in ['INBOX', 'UNREAD', 'SPAM', 'TRASH', 'CATEGORY_SOCIAL']:
+            assert label in _HIDDEN_LABELS
+
+    def test_user_labels_not_hidden(self):
+        assert 'Triage/Jira' not in _HIDDEN_LABELS
+        assert 'Label_1' not in _HIDDEN_LABELS


### PR DESCRIPTION
  Implement label-based inbox classification, auto-cleanup of noise, and terminal dashboard
  with clickable Gmail links. Extend Gmail client with batch operations and label management.
  Register 7 MCP tools and add comprehensive test coverage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automated inbox triage workflow that intelligently classifies and groups unread emails
  * Advanced label management: create custom labels and organize emails with batch operations
  * Bulk delete and archive functionality for efficient inbox cleanup
  * Watch mode for continuous inbox monitoring at configurable intervals
  * Interactive dashboard with direct Gmail search links for each email group

* **Documentation**
  * Added email management and triage workflow guides

* **Chores**
  * Added comprehensive test coverage
  * Introduced Makefile for streamlined command execution

<!-- end of auto-generated comment: release notes by coderabbit.ai -->