### PR TITLE
Restore unread counter label and header decrement on action

### DIFF
--- a/static/dashboard.js
+++ b/static/dashboard.js
@@ -889,6 +889,12 @@ async function emailAction(action, email, itemEl) {
                 }
             }
 
+            // Decrement the header unread counter if email was unread
+            if (email.isUnread) {
+                const current = parseInt(totalEmailsEl.textContent, 10) || 0;
+                totalEmailsEl.textContent = Math.max(0, current - 1);
+            }
+
             // Remove the item from the DOM after the animation, then check if group is now empty
             setTimeout(() => {
                 itemEl.remove();

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -22,7 +22,7 @@
                         Last sync: <span id="lastSync">Never</span>
                     </span>
                     <span class="stat">
-                        New emails: <span id="totalEmails">-</span>
+                        Unread emails: <span id="totalEmails">-</span>
                     </span>
                     <span class="stat">
                         Next sync: <span id="nextSync">-</span>


### PR DESCRIPTION
  - dashboard.html: rename New emails to Unread emails in header
  - dashboard.js: decrement header unread counter when archiving or deleting an unread email (same isUnread guard as badge decrement)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Header unread emails counter now properly decrements when emails are acted upon
  * Updated display label from "New emails" to "Unread emails" for clarity

<!-- end of auto-generated comment: release notes by coderabbit.ai -->