### PR TITLE
Surface auth errors in dashboard; extend notifications to 15s

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help triage watch dashboard kill-dashboard
+.PHONY: help auth triage watch dashboard kill-dashboard
 
 .DEFAULT_GOAL := help
 
@@ -7,6 +7,14 @@ MODEL ?= haiku
 help: ## List available commands
 	@echo "Available commands:"
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  make %-15s %s\n", $$1, $$2}'
+
+auth: ## Initialize Gmail OAuth authentication (requires credentials.json)
+	@if [ ! -f credentials.json ]; then \
+		echo "Error: credentials.json not found."; \
+		echo "Download it from Google Cloud Console and place it in this directory."; \
+		exit 1; \
+	fi
+	python3 -m gmail_mcp_server.auth
 
 triage: ## Run inbox triage (MODEL=haiku|sonnet|opus)
 	./scripts/inbox-manager.sh --model $(MODEL)

--- a/README.md
+++ b/README.md
@@ -127,6 +127,9 @@ Use the included Makefile for quick access to common tasks:
 # Display available commands
 make help
 
+# Initialize Gmail OAuth authentication (requires credentials.json)
+make auth
+
 # Start the web dashboard
 make dashboard
 
@@ -198,25 +201,35 @@ Archives an email (removes from inbox) by ID.
 On first run, the server requires authentication. Use the provided authentication helper:
 
 ```bash
-gmail-mcp-auth
+make auth
 ```
 
-This will:
-1. Open a browser window for OAuth 2.0 authentication
-2. Request permission to access your Gmail account
-3. Save the authentication token to `token.json` for future use
-
-If you installed in development mode, you can also run:
+Or manually:
 ```bash
 python -m gmail_mcp_server.auth
 ```
+
+This will:
+1. Check that `credentials.json` exists in the project root
+2. Open a browser window for OAuth 2.0 authentication
+3. Request permission to access your Gmail account
+4. Save the authentication token to `token.json` for future use
+
+### Getting Credentials
+
+Before running `make auth`, you need to set up Google OAuth 2.0 credentials:
+1. Go to [Google Cloud Console](https://console.cloud.google.com/)
+2. Create a new project or select an existing one
+3. Enable the Gmail API
+4. Create OAuth 2.0 credentials (Desktop application)
+5. Download the credentials JSON file and save as `credentials.json` in the project root
 
 ### How It Works
 
 - The server checks for an existing authentication token (`token.json`) on startup
 - If the token exists and is valid, the server uses it automatically
 - If the token is expired but has a refresh token, it refreshes automatically
-- If no token exists, the server will request authentication using the `gmail-mcp-auth` command
+- If no token exists, the server will request authentication using the `make auth` command
 
 ### Required Gmail API Scopes
 

--- a/app.py
+++ b/app.py
@@ -22,22 +22,40 @@ gmail_client = GmailClient()
 TRIAGE_MODEL = 'claude-haiku-4-5'
 triage_model = TRIAGE_MODEL  # mutable runtime selection
 
+# Keywords that indicate an authentication/authorization failure
+_AUTH_KEYWORDS = ['auth', 'token', 'credential', 'unauthorized', 'unauthenticated',
+                  '401', '403', 'refresh', 'login', 'permission', 'access denied']
+
+class AuthError(Exception):
+    pass
+
 triage_cache = {
     'data': None,
     'timestamp': None,
     'next_sync': None,
     'model': None,
     'last_unread_count': None,
+    'error': None,  # {'type': 'auth'|'other', 'message': str} when set
 }
 triage_lock = threading.Lock()
 
+def _is_auth_error(exc: Exception) -> bool:
+    """Return True if the exception looks like an authentication failure."""
+    msg = str(exc).lower()
+    return any(kw in msg for kw in _AUTH_KEYWORDS)
+
 def get_inbox_unread_count():
-    """Return the number of unread emails in INBOX, or None on error."""
+    """Return the number of unread emails in INBOX.
+
+    Raises AuthError if authentication fails; returns None for other errors.
+    """
     try:
         gmail_client._ensure_authenticated()
         result = gmail_client.service.users().labels().get(userId='me', id='INBOX').execute()
         return result.get('messagesUnread', 0)
     except Exception as e:
+        if _is_auth_error(e):
+            raise AuthError(str(e))
         print(f"[unread_count] Error: {e}")
         return None
 
@@ -54,11 +72,15 @@ def run_triage():
 
         if result.returncode != 0:
             print(f"Triage error (code {result.returncode})")
+            combined_output = (result.stderr or '') + (result.stdout or '')
+            combined_lower = combined_output.lower()
+            if any(kw in combined_lower for kw in _AUTH_KEYWORDS):
+                raise AuthError(f"Claude CLI authentication error (code {result.returncode}): {combined_output.strip()}")
             return {
                 'labeled_groups': [],
                 'auto_cleaned': {'archived': [], 'deleted': []},
                 'summary': {'total': 0, 'labeled': 0, 'archived': 0, 'deleted': 0},
-                'raw_output': f"Error running triage (code {result.returncode}): {result.stderr or result.stdout}",
+                'raw_output': f"Error running triage (code {result.returncode}): {combined_output}",
                 'model': triage_model,
             }
 
@@ -79,6 +101,8 @@ def run_triage():
             }
         parsed['model'] = model
         return parsed
+    except AuthError:
+        raise  # propagate auth errors to the caller
     except FileNotFoundError:
         print("Error: 'claude' command not found. Make sure Claude Code CLI is installed.")
         return None
@@ -259,6 +283,7 @@ def get_triage():
         'timestamp': triage_cache['timestamp'],
         'next_sync': next_sync,
         'model': triage_cache.get('model'),
+        'error': triage_cache.get('error'),
     })
 
 @app.route('/api/triage/refresh', methods=['POST'])
@@ -270,15 +295,27 @@ def refresh_triage():
     try:
         print("=== Triage refresh triggered ===")
 
-        unread_count = get_inbox_unread_count()
+        try:
+            unread_count = get_inbox_unread_count()
+        except AuthError as e:
+            msg = f"Gmail authentication failed: {e}"
+            print(f"[triage] Auth error during unread count: {e}")
+            triage_cache['error'] = {'type': 'auth', 'message': msg}
+            return jsonify({'success': False, 'auth_error': True, 'error': msg}), 401
+
         print(f"[triage] inbox unread count: {unread_count}")
         if unread_count is not None:
             if unread_count == 0:
                 print("[triage] Skipping — no unread emails")
                 return jsonify({'success': False, 'skipped': True, 'reason': 'No unread emails found'})
 
-
-        data = run_triage()
+        try:
+            data = run_triage()
+        except AuthError as e:
+            msg = f"Claude CLI authentication failed: {e}"
+            print(f"[triage] Auth error during triage run: {e}")
+            triage_cache['error'] = {'type': 'auth', 'message': msg}
+            return jsonify({'success': False, 'auth_error': True, 'error': msg}), 401
 
         if data:
             current_time = datetime.now()
@@ -287,6 +324,7 @@ def refresh_triage():
             triage_cache['next_sync'] = (current_time + timedelta(minutes=15)).isoformat()
             triage_cache['model'] = data.get('model')
             triage_cache['last_unread_count'] = unread_count
+            triage_cache['error'] = None
             print("Triage succeeded")
             return jsonify({
                 'success': True,
@@ -481,14 +519,28 @@ if __name__ == '__main__':
         time.sleep(1)
         print("Running initial triage in background...")
         with triage_lock:
-            unread_count = get_inbox_unread_count()
+            try:
+                unread_count = get_inbox_unread_count()
+            except AuthError as e:
+                msg = f"Gmail authentication failed: {e}"
+                print(f"[triage] Auth error during initial unread count: {e}")
+                triage_cache['error'] = {'type': 'auth', 'message': msg}
+                triage_cache['timestamp'] = datetime.now().isoformat()
+                return
             print(f"[triage] inbox unread count: {unread_count}")
             if unread_count == 0:
                 print("[triage] Skipping initial triage — no unread emails")
                 triage_cache['timestamp'] = datetime.now().isoformat()
                 triage_cache['data'] = {'labeled_groups': [], 'summary': {}, 'auto_cleaned': {}}
                 return
-            data = run_triage()
+            try:
+                data = run_triage()
+            except AuthError as e:
+                msg = f"Claude CLI authentication failed: {e}"
+                print(f"[triage] Auth error during initial triage run: {e}")
+                triage_cache['error'] = {'type': 'auth', 'message': msg}
+                triage_cache['timestamp'] = datetime.now().isoformat()
+                return
             if data:
                 triage_cache['data'] = data
                 triage_cache['timestamp'] = datetime.now().isoformat()

--- a/static/dashboard.js
+++ b/static/dashboard.js
@@ -145,6 +145,10 @@ document.addEventListener('DOMContentLoaded', () => {
 async function startRefreshCycle() {
     // Phase 1: try to load cached data immediately
     const cached = await fetchTriage();
+    if (cached?.error?.type === 'auth') {
+        showAuthError(cached.error.message);
+        return; // Don't start the cycle — auth must be fixed first
+    }
     if (cached && cached.data) {
         // Cached data exists — render immediately, no loading message
         lastTimestamp = cached.timestamp;
@@ -208,7 +212,18 @@ function pollUntilData() {
         const timer = setInterval(async () => {
             try {
                 const result = await fetchTriage();
-                if (!result || !result.data) return;
+                if (!result) return;
+
+                // Auth error stored in cache — surface it immediately
+                if (result.error?.type === 'auth') {
+                    clearInterval(timer);
+                    hideSpinner();
+                    showAuthError(result.error.message);
+                    resolve();
+                    return;
+                }
+
+                if (!result.data) return;
 
                 const isNew = result.timestamp && result.timestamp !== lastTimestamp;
 
@@ -264,6 +279,14 @@ async function handleManualRefresh() {
     previousLiveUnreadTotal = -1;
 
     const triageResult = await triggerTriage();
+
+    if (triageResult?.auth_error) {
+        hideSpinner();
+        showAuthError(triageResult.error);
+        refreshBtn.disabled = false;
+        refreshBtn.textContent = '⟳ Refresh Now';
+        return;
+    }
 
     if (triageResult?.skipped) {
         hideSpinner();
@@ -518,6 +541,20 @@ function renderArchivedItems() {
     if (autoArchivedItems.length === 0 && manuallyArchived.length === 0) {
         container.innerHTML = '<p class="archived-empty">No archived emails this session</p>';
     }
+}
+
+function showAuthError(message) {
+    quickLinksContainer.innerHTML = `
+        <div class="auth-error-banner">
+            <div class="auth-error-icon">🔐</div>
+            <div class="auth-error-title">Authentication Error</div>
+            <div class="auth-error-message">${message || 'Gmail or Claude authentication failed. Please re-authenticate and restart the server.'}</div>
+            <div class="auth-error-hint">Check the server console for details, then restart <code>make run</code>.</div>
+        </div>
+    `;
+    currentSummaryGroup = null;
+    summaryContainer.innerHTML = '<div class="summary-hint"><div class="summary-hint-icon">🔐</div>Authentication required</div>';
+    emailBodyContainer.innerHTML = '<div class="summary-hint"><div class="summary-hint-icon">🔑</div>Re-authenticate to continue</div>';
 }
 
 function showEmptyInbox() {
@@ -1083,6 +1120,7 @@ function sendNewEmailNotification(count, groups) {
             window.focus();
             notification.close();
         };
+        setTimeout(() => notification.close(), 15000);
     } catch (e) {
         console.error('Failed to send notification:', e);
     }

--- a/static/style.css
+++ b/static/style.css
@@ -1007,6 +1007,49 @@ body {
     line-height: 1.2;
 }
 
+.auth-error-banner {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    padding: 40px 24px;
+    gap: 10px;
+    text-align: center;
+    color: var(--text-light);
+}
+
+.auth-error-icon {
+    font-size: 48px;
+    line-height: 1.2;
+}
+
+.auth-error-title {
+    font-size: 16px;
+    font-weight: 600;
+    color: #c0392b;
+}
+
+.auth-error-message {
+    font-size: 13px;
+    color: var(--text-secondary, #888);
+    max-width: 280px;
+    line-height: 1.5;
+}
+
+.auth-error-hint {
+    font-size: 12px;
+    color: var(--text-light);
+    margin-top: 4px;
+}
+
+.auth-error-hint code {
+    background: var(--bg-secondary, #f4f4f4);
+    padding: 1px 5px;
+    border-radius: 3px;
+    font-family: monospace;
+    font-size: 11px;
+}
+
 /* Responsive */
 @media (max-width: 1200px) {
     .cards-row {


### PR DESCRIPTION
  - Add AuthError class and _is_auth_error helper to app.py
  - get_inbox_unread_count raises AuthError on auth failures instead of returning None, catching the problem before triage is invoked
  - run_triage detects auth keywords in subprocess output and raises AuthError
  - refresh_triage and run_initial_triage catch AuthError, store in triage_cache error field, return HTTP 401 with auth_error flag
  - GET /api/triage now exposes cached error field to frontend
  - startRefreshCycle, pollUntilData, handleManualRefresh all detect auth errors and call showAuthError to render a banner in the UI
  - Add showAuthError function and auth-error-banner CSS styles
  - Extend browser notification auto-close to 15 seconds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `make auth` command for initializing Gmail OAuth authentication with credential validation
  * Implemented authentication error detection with user-friendly error messages displayed in the dashboard

* **Documentation**
  * Updated setup and workflow documentation to reference the new authentication command

* **Style**
  * Added styling for authentication error notifications in the UI

<!-- end of auto-generated comment: release notes by coderabbit.ai -->