### PR TITLE
Increase triage timeout to 5 minutes and persist loading timer throug…

### DIFF
--- a/app.py
+++ b/app.py
@@ -66,7 +66,7 @@ def run_triage():
             ['claude', '-p', '/triage', '--model', triage_model],
             capture_output=True,
             text=True,
-            timeout=180,
+            timeout=300,
             cwd=os.path.dirname(os.path.abspath(__file__))
         )
 
@@ -107,7 +107,7 @@ def run_triage():
         print("Error: 'claude' command not found. Make sure Claude Code CLI is installed.")
         return None
     except subprocess.TimeoutExpired:
-        print("Triage timed out after 180 seconds")
+        print("Triage timed out after 300 seconds")
         return None
     except Exception as e:
         print(f"Error running triage: {e}")
@@ -335,9 +335,11 @@ def refresh_triage():
             })
         else:
             print("Triage failed - no data returned")
+            msg = 'Triage timed out or failed. Check console output for details.'
+            triage_cache['error'] = {'type': 'other', 'message': msg}
             return jsonify({
                 'success': False,
-                'error': 'Failed to run triage. Check console output for details.'
+                'error': {'type': 'other', 'message': msg}
             }), 500
     finally:
         triage_lock.release()

--- a/static/dashboard.js
+++ b/static/dashboard.js
@@ -16,7 +16,7 @@ const EARLY_WAKE = 60 * 1000;             // wake 1 minute early
 let triageData = null;
 let lastTimestamp = null; // track when data last changed
 let loadingTimerInterval = null;
-let loadingStartTime = null;
+let loadingStartTime = localStorage.getItem('loadingStartTime') ? parseInt(localStorage.getItem('loadingStartTime'), 10) : null;
 let currentSummaryGroup = null;
 let manuallyArchived = JSON.parse(sessionStorage.getItem('manuallyArchived') || '[]'); // {id, subject, sender}
 let manuallyDeleted = JSON.parse(sessionStorage.getItem('manuallyDeleted') || '[]'); // {id, subject, sender}
@@ -223,6 +223,15 @@ function pollUntilData() {
                     return;
                 }
 
+                // Other error types (timeout, etc.) — surface and stop polling
+                if (result.error?.type === 'other') {
+                    clearInterval(timer);
+                    hideSpinner();
+                    showError(result.error.message);
+                    resolve();
+                    return;
+                }
+
                 if (!result.data) return;
 
                 const isNew = result.timestamp && result.timestamp !== lastTimestamp;
@@ -230,6 +239,18 @@ function pollUntilData() {
                 if (isNew || !lastTimestamp) {
                     clearInterval(timer);
                     lastTimestamp = result.timestamp;
+
+                    // If server timestamp is much newer than our loading start time,
+                    // the server was restarted — reset the timer to show correct elapsed time
+                    if (loadingStartTime && result.timestamp) {
+                        const serverTime = new Date(result.timestamp).getTime();
+                        const timeDiff = serverTime - loadingStartTime;
+                        // If more than 10 seconds difference, assume server restarted
+                        if (timeDiff > 10000) {
+                            loadingStartTime = serverTime;
+                        }
+                    }
+
                     triageData = Object.assign(result.data, { model: result.model });
                     updateUI();
                     updateSyncTimes(result);
@@ -319,19 +340,29 @@ async function fetchTriage() {
 
 function showSpinner() {
     headerSpinner.classList.remove('hidden');
-    startLoadingTimer();
+    // Don't restart the timer if it's already running (e.g., page refresh during triage)
+    if (!loadingTimerInterval) {
+        startLoadingTimer();
+    }
 }
 
 function hideSpinner() {
     headerSpinner.classList.add('hidden');
     stopLoadingTimer();
+    // Clear persisted loading start time when triage completes (spinner is done)
+    // Keep loadingStartTime in memory for updateUI to show "Load: X:XX" in Quick Links
+    localStorage.removeItem('loadingStartTime');
 }
 
 // ─── Loading elapsed timer ───────────────────────────────────
 
 function startLoadingTimer() {
     stopLoadingTimer();
-    loadingStartTime = Date.now();
+    // If loading start time wasn't set (fresh triage), set it now
+    // Otherwise keep the existing one (from page refresh during triage)
+    if (!loadingStartTime) {
+        loadingStartTime = Date.now();
+    }
     updateLoadingTimerDisplay(0);
     loadingTimerInterval = setInterval(() => {
         const elapsed = Math.floor((Date.now() - loadingStartTime) / 1000);
@@ -567,6 +598,20 @@ function showAuthError(message) {
     currentSummaryGroup = null;
     summaryContainer.innerHTML = '<div class="summary-hint"><div class="summary-hint-icon">🔐</div>Authentication required</div>';
     emailBodyContainer.innerHTML = '<div class="summary-hint"><div class="summary-hint-icon">🔑</div>Re-authenticate to continue</div>';
+}
+
+function showError(message) {
+    quickLinksContainer.innerHTML = `
+        <div class="auth-error-banner">
+            <div class="auth-error-icon">⚠️</div>
+            <div class="auth-error-title">Triage Error</div>
+            <div class="auth-error-message">${message || 'Triage failed. Check the server console for details.'}</div>
+            <div class="auth-error-hint">Press <strong>Refresh Now</strong> to try again.</div>
+        </div>
+    `;
+    currentSummaryGroup = null;
+    summaryContainer.innerHTML = '<div class="summary-hint"><div class="summary-hint-icon">⚠️</div>Triage failed</div>';
+    emailBodyContainer.innerHTML = '<div class="summary-hint"><div class="summary-hint-icon">🔄</div>Try refreshing</div>';
 }
 
 function showEmptyInbox() {


### PR DESCRIPTION
…h page refresh

  - Increase triage subprocess timeout from 180 to 300 seconds (5 minutes)
  - Fix timeout error handling: store errors in cache and return as JSON instead of leaving spinner stuck
  - Add localStorage persistence for triage timer so it continues counting across page refreshes
  - Don't restart timer on page refresh during triage to preserve elapsed time
  - Detect server restarts: reset timer if server timestamp indicates new triage was started
  - Add showError() function to display non-auth errors with retry hint
  - Handle error?.type === 'other' in polling to stop waiting for data that will never arrive

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced an error notification banner that displays to users when triage operations fail due to processing errors.

* **Bug Fixes**
  * Extended triage subprocess timeout to allow longer processing time.
  * Improved loading timer behavior to maintain accuracy across page refreshes and user interactions.
  * Enhanced error response messages with structured formatting for clearer error communication to users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->