### PR TITLE
Add optional PIN security to the web dashboard. A number pad overlay …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,5 @@ GEMINI.md
 .sync-commands/
 logs/
 tests/test_server.py
+.pincode
+.flask_secret

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help auth triage watch dashboard kill-dashboard
+.PHONY: help auth triage watch dashboard kill-dashboard set-pin
 
 .DEFAULT_GOAL := help
 
@@ -31,3 +31,15 @@ dashboard: ## Start the web dashboard (auto-restarts on crash)
 
 kill-dashboard: ## Kill the running dashboard server
 	@pkill -f 'python3 app.py' && echo "Dashboard stopped." || echo "No dashboard running."
+
+set-pin: ## Set or change the dashboard PIN (prompts for PIN twice)
+	@python3 -c "\
+import getpass, secrets, hashlib, sys; \
+from pathlib import Path; \
+p1 = getpass.getpass('Enter new PIN: '); \
+p2 = getpass.getpass('Confirm PIN: '); \
+sys.exit('Error: PINs do not match.') if p1 != p2 else None; \
+salt = secrets.token_hex(16); \
+h = hashlib.pbkdf2_hmac('sha256', p1.encode(), salt.encode(), 260000).hex(); \
+Path('.pincode').write_text(f'{salt}:{h}'); \
+print('PIN saved.')"

--- a/README.md
+++ b/README.md
@@ -119,6 +119,74 @@ Place the `.mcp.json` file in your home directory or specify the path when runni
 
 Once configured, you can use the Gmail MCP server with AI assistants by passing it in your client configuration.
 
+## Dashboard PIN Security
+
+The dashboard can be protected with a 4-digit PIN. When configured, the dashboard shows a PIN entry screen on every new session (sessions last 4 hours).
+
+### Setting a PIN
+
+```bash
+make set-pin
+# Enter new PIN: ****
+# Confirm PIN: ****
+# PIN saved.
+```
+
+Or use the Python CLI directly:
+```bash
+python3 app.py --set-pin
+```
+
+This writes a PBKDF2-SHA256 hashed PIN to `.pincode` in the project root. The raw PIN is never stored. Both `.pincode` and `.flask_secret` are gitignored.
+
+To remove PIN protection, delete `.pincode`:
+```bash
+rm .pincode
+```
+
+### Running in Kubernetes
+
+When running as a container in Kubernetes, mount the pre-hashed `.pincode` value as a Secret rather than generating it on-disk.
+
+**1. Generate the hash locally:**
+```bash
+python3 -c "
+import secrets, hashlib
+pin = '1234'  # replace with your PIN
+salt = secrets.token_hex(16)
+h = hashlib.pbkdf2_hmac('sha256', pin.encode(), salt.encode(), 260000).hex()
+print(f'{salt}:{h}')
+"
+```
+
+**2. Create a Kubernetes Secret:**
+```bash
+kubectl create secret generic gmail-dashboard-pin \
+  --from-literal=pincode='<salt:hash from above>' \
+  --from-literal=flask-secret-key="$(python3 -c 'import secrets; print(secrets.token_hex(32))')"
+```
+
+**3. Mount it in your Pod spec:**
+```yaml
+env:
+  - name: FLASK_SECRET_KEY
+    valueFrom:
+      secretKeyRef:
+        name: gmail-dashboard-pin
+        key: flask-secret-key
+volumeMounts:
+  - name: pin-secret
+    mountPath: /app/.pincode
+    subPath: pincode
+    readOnly: true
+volumes:
+  - name: pin-secret
+    secret:
+      secretName: gmail-dashboard-pin
+```
+
+The app reads `.pincode` from the working directory (or override with `PINCODE_PATH` if you prefer a different location). The `FLASK_SECRET_KEY` env var takes precedence over the auto-generated `.flask_secret` file, which is what you want for a stateless container.
+
 ## Make Commands
 
 Use the included Makefile for quick access to common tasks:
@@ -129,6 +197,9 @@ make help
 
 # Initialize Gmail OAuth authentication (requires credentials.json)
 make auth
+
+# Set or change the dashboard PIN
+make set-pin
 
 # Start the web dashboard
 make dashboard

--- a/app.py
+++ b/app.py
@@ -6,23 +6,67 @@ A clean web interface for Gmail inbox triage with auto-refresh every 15 minutes.
 
 import os
 import re
+import sys
 import json
 import ssl
 import time
+import secrets
+import hashlib
+import getpass
 import subprocess
 import threading
 from datetime import datetime, timedelta
-from flask import Flask, render_template, jsonify, request, make_response
+from functools import wraps
+from flask import Flask, render_template, jsonify, request, make_response, session
 from pathlib import Path
 
 from gmail_mcp_server.gmail_client import GmailClient
 from googleapiclient.errors import HttpError
 
+def _load_or_generate_secret():
+    secret_file = Path('.flask_secret')
+    if secret_file.exists():
+        return secret_file.read_text().strip()
+    key = secrets.token_hex(32)
+    secret_file.write_text(key)
+    return key
+
 app = Flask(__name__, static_folder='static', template_folder='templates')
+app.secret_key = os.environ.get('FLASK_SECRET_KEY') or _load_or_generate_secret()
+app.config['PERMANENT_SESSION_LIFETIME'] = timedelta(hours=4)
 gmail_client = GmailClient()
 # httplib2 (used inside google-api-python-client) is not thread-safe.
 # All gmail_client calls must hold this lock to prevent concurrent SSL access → SIGSEGV.
 gmail_client_lock = threading.Lock()
+
+# ── PIN helpers ───────────────────────────────────────────────
+
+def _load_pin_hash():
+    p = Path('.pincode')
+    if not p.exists():
+        return None, None
+    salt, h = p.read_text().strip().split(':')
+    return salt, h
+
+def _verify_pin(pin):
+    salt, stored = _load_pin_hash()
+    if salt is None:
+        return True  # no PIN configured
+    candidate = hashlib.pbkdf2_hmac('sha256', pin.encode(), salt.encode(), 260000).hex()
+    return secrets.compare_digest(candidate, stored)
+
+def _pin_configured():
+    return Path('.pincode').exists()
+
+def require_pin(f):
+    @wraps(f)
+    def decorated(*args, **kwargs):
+        if _pin_configured() and not session.get('pin_ok'):
+            return jsonify({'error': 'pin_required'}), 401
+        return f(*args, **kwargs)
+    return decorated
+
+# ── Triage cache ───────────────────────────────────────────────
 
 # Store triage results in memory with timestamp
 TRIAGE_MODEL = 'claude-haiku-4-5'
@@ -303,6 +347,19 @@ def parse_triage_output(output):
         traceback.print_exc()
         return None
 
+@app.route('/api/pin/status')
+def pin_status():
+    return jsonify({'configured': _pin_configured(), 'authenticated': bool(session.get('pin_ok'))})
+
+@app.route('/api/pin/verify', methods=['POST'])
+def pin_verify():
+    pin = request.json.get('pin', '')
+    if _verify_pin(pin):
+        session.permanent = True
+        session['pin_ok'] = True
+        return jsonify({'ok': True})
+    return jsonify({'ok': False}), 401
+
 @app.route('/')
 def index():
     """Serve the dashboard HTML"""
@@ -312,6 +369,7 @@ def index():
     return response
 
 @app.route('/api/triage', methods=['GET'])
+@require_pin
 def get_triage():
     """API endpoint to get current triage data"""
     next_sync = None
@@ -328,6 +386,7 @@ def get_triage():
     })
 
 @app.route('/api/triage/refresh', methods=['POST'])
+@require_pin
 def refresh_triage():
     """API endpoint to manually trigger triage"""
     if not triage_lock.acquire(blocking=False):
@@ -389,6 +448,7 @@ def refresh_triage():
         triage_lock.release()
 
 @app.route('/api/emails/counts', methods=['GET'])
+@require_pin
 def get_email_counts():
     """Fetch total and unread counts for multiple labels via a single Gmail API batch request."""
     labels = request.args.getlist('label')
@@ -454,6 +514,7 @@ def get_email_counts():
 
 
 @app.route('/api/emails', methods=['GET'])
+@require_pin
 def get_emails_by_label():
     """Fetch emails from Gmail matching a label, returning subjects + message IDs."""
     label_name = request.args.get('label', '')
@@ -506,6 +567,7 @@ def get_emails_by_label():
 
 
 @app.route('/api/labels/triage', methods=['GET'])
+@require_pin
 def get_triage_labels():
     """Return all Triage/* label names currently in Gmail."""
     try:
@@ -526,10 +588,12 @@ ALLOWED_MODELS = {
 }
 
 @app.route('/api/model', methods=['GET'])
+@require_pin
 def get_model():
     return jsonify({'model': triage_model})
 
 @app.route('/api/model', methods=['POST'])
+@require_pin
 def set_model():
     global triage_model
     data = request.get_json()
@@ -542,6 +606,7 @@ def set_model():
 
 
 @app.route('/api/emails/readstate', methods=['POST'])
+@require_pin
 def set_email_readstate():
     """Mark an email as read or unread."""
     data = request.get_json()
@@ -561,6 +626,7 @@ def set_email_readstate():
 
 
 @app.route('/api/emails/archive', methods=['POST'])
+@require_pin
 def archive_email():
     """Archive an email by message ID."""
     data = request.get_json()
@@ -576,6 +642,7 @@ def archive_email():
 
 
 @app.route('/api/emails/delete', methods=['POST'])
+@require_pin
 def delete_email():
     """Delete an email by message ID."""
     data = request.get_json()
@@ -591,6 +658,14 @@ def delete_email():
 
 
 if __name__ == '__main__':
+    if '--set-pin' in sys.argv:
+        pin = getpass.getpass('Enter new PIN: ')
+        salt = secrets.token_hex(16)
+        h = hashlib.pbkdf2_hmac('sha256', pin.encode(), salt.encode(), 260000).hex()
+        Path('.pincode').write_text(f'{salt}:{h}')
+        print('PIN saved.')
+        sys.exit(0)
+
     print("Starting Flask app on http://localhost:5000")
     print("Press Ctrl+C to stop")
 

--- a/static/dashboard.js
+++ b/static/dashboard.js
@@ -139,7 +139,7 @@ function setUnreadCount(n) {
 
 // ─── Initialization ───────────────────────────────────────────
 
-document.addEventListener('DOMContentLoaded', () => {
+function startApp() {
     // Render the header icon immediately so it doesn't show as broken during first sync
     updateFaviconBadge(0);
 
@@ -230,7 +230,89 @@ document.addEventListener('DOMContentLoaded', () => {
     // Load quick links immediately from live Gmail labels, in parallel with triage
     updateQuickLinks();
     startRefreshCycle();
-});
+}
+
+document.addEventListener('DOMContentLoaded', checkPinAuth);
+
+// ─── PIN Auth ─────────────────────────────────────────────────
+
+async function checkPinAuth() {
+    try {
+        const res = await fetch('/api/pin/status');
+        const data = await res.json();
+        if (!data.configured || data.authenticated) {
+            startApp();
+        } else {
+            document.getElementById('pinOverlay').classList.remove('hidden');
+            initPinPad();
+        }
+    } catch(e) {
+        startApp(); // fail open if status check fails
+    }
+}
+
+let pinDigits = [];
+
+function initPinPad() {
+    document.querySelectorAll('.pin-btn[data-digit]').forEach(btn => {
+        btn.addEventListener('click', () => pinInput(btn.dataset.digit));
+    });
+    document.getElementById('pinBack').addEventListener('click', pinBackspace);
+    document.getElementById('pinClear').addEventListener('click', pinClearAll);
+    document.getElementById('pinSubmit').addEventListener('click', submitPin);
+    document.addEventListener('keydown', e => {
+        if (/^[0-9]$/.test(e.key)) pinInput(e.key);
+        else if (e.key === 'Backspace') pinBackspace();
+        else if (e.key === 'Enter') submitPin();
+    });
+}
+
+function pinInput(digit) {
+    pinDigits.push(digit);
+    updatePinDots();
+}
+
+function pinBackspace() {
+    pinDigits.pop();
+    updatePinDots();
+}
+
+function pinClearAll() {
+    pinDigits = [];
+    updatePinDots();
+}
+
+function updatePinDots() {
+    const container = document.getElementById('pinDots');
+    container.innerHTML = '';
+    const count = Math.max(pinDigits.length, 1);
+    for (let i = 0; i < count; i++) {
+        const dot = document.createElement('span');
+        dot.className = 'pin-dot' + (i < pinDigits.length ? ' filled' : '');
+        container.appendChild(dot);
+    }
+}
+
+async function submitPin() {
+    if (pinDigits.length === 0) return;
+    const pin = pinDigits.join('');
+    const res = await fetch('/api/pin/verify', {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({pin})
+    });
+    if (res.ok) {
+        document.getElementById('pinOverlay').classList.add('hidden');
+        startApp();
+    } else {
+        const card = document.getElementById('pinCard');
+        card.classList.add('shake');
+        document.getElementById('pinError').textContent = 'Incorrect PIN';
+        setTimeout(() => { card.classList.remove('shake'); }, 400);
+        pinDigits = [];
+        updatePinDots();
+    }
+}
 
 // ─── Core refresh cycle ───────────────────────────────────────
 

--- a/static/style.css
+++ b/static/style.css
@@ -1251,6 +1251,57 @@ body {
     }
 }
 
+/* PIN Overlay */
+.pin-overlay {
+  position: fixed; inset: 0; z-index: 9999;
+  background: var(--lighter);
+  display: flex; align-items: center; justify-content: center;
+}
+.pin-overlay.hidden { display: none; }
+.pin-card {
+  background: white; border-radius: 16px;
+  box-shadow: 0 8px 32px rgba(0,0,0,0.12);
+  padding: 2rem 1.5rem; width: 320px; max-width: 92vw;
+  text-align: center;
+}
+.pin-title { font-size: 1.1rem; font-weight: 600; margin: 0 0 0.25rem; color: var(--primary); }
+.pin-dots { display: flex; flex-wrap: wrap; gap: 12px; justify-content: center; margin: 1.25rem 0 0.5rem; min-height: 16px; }
+.pin-dot {
+  width: 16px; height: 16px; border-radius: 50%;
+  border: 2px solid var(--border); background: transparent;
+  transition: background 0.12s, border-color 0.12s;
+}
+.pin-dot.filled { background: var(--accent); border-color: var(--accent); }
+.pin-error { color: var(--danger); font-size: 0.8rem; min-height: 1.4em; margin-bottom: 0.75rem; }
+.pin-pad { display: grid; grid-template-columns: repeat(3, 1fr); gap: 10px; }
+.pin-btn {
+  aspect-ratio: 1; border-radius: 50%; font-size: 1.4rem; font-weight: 500;
+  border: 1px solid var(--border); background: var(--lighter);
+  cursor: pointer; transition: background 0.12s, transform 0.08s;
+  display: flex; align-items: center; justify-content: center;
+  min-height: 68px; color: var(--primary);
+  -webkit-tap-highlight-color: transparent;
+}
+.pin-btn:hover { background: var(--light); }
+.pin-btn:active { background: var(--border); transform: scale(0.94); }
+.pin-btn-action { font-size: 1rem; color: var(--secondary); }
+@keyframes shake {
+  0%,100% { transform: translateX(0); }
+  20%,60% { transform: translateX(-10px); }
+  40%,80% { transform: translateX(10px); }
+}
+.pin-card.shake { animation: shake 0.38s ease; }
+.pin-submit-btn {
+  display: block; width: 100%; margin-top: 14px;
+  padding: 14px; border-radius: 10px; border: none;
+  background: var(--accent); color: white;
+  font-size: 1rem; font-weight: 600; cursor: pointer;
+  transition: background 0.15s;
+  -webkit-tap-highlight-color: transparent;
+}
+.pin-submit-btn:hover { background: #2563eb; }
+.pin-submit-btn:active { background: #1d4ed8; }
+
 @media (max-width: 768px) {
     .summary-pane,
     .cards-row {

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -116,5 +116,29 @@
     </div>
 
     <script src="{{ url_for('static', filename='dashboard.js') }}?v={{ cache_bust }}"></script>
+
+    <div id="pinOverlay" class="pin-overlay hidden">
+      <div class="pin-card" id="pinCard">
+        <img src="/static/gmail-logo.png" height="16" style="width:auto;margin-bottom:1rem" alt="Gmail">
+        <h2 class="pin-title">Enter PIN</h2>
+        <div class="pin-dots" id="pinDots"></div>
+        <div class="pin-error" id="pinError">&nbsp;</div>
+        <div class="pin-pad">
+          <button class="pin-btn" data-digit="1">1</button>
+          <button class="pin-btn" data-digit="2">2</button>
+          <button class="pin-btn" data-digit="3">3</button>
+          <button class="pin-btn" data-digit="4">4</button>
+          <button class="pin-btn" data-digit="5">5</button>
+          <button class="pin-btn" data-digit="6">6</button>
+          <button class="pin-btn" data-digit="7">7</button>
+          <button class="pin-btn" data-digit="8">8</button>
+          <button class="pin-btn" data-digit="9">9</button>
+          <button class="pin-btn pin-btn-action" id="pinClear">C</button>
+          <button class="pin-btn" data-digit="0">0</button>
+          <button class="pin-btn pin-btn-action" id="pinBack">&#x232B;</button>
+        </div>
+        <button class="pin-submit-btn" id="pinSubmit">Unlock</button>
+      </div>
+    </div>
 </body>
 </html>


### PR DESCRIPTION
…gates access when a .pincode file is present. PINs are hashed

  with PBKDF2-SHA256 and a random salt, never stored in plaintext. Sessions last 4 hours. All API routes are protected except the PIN
   verify endpoints. Use make set-pin or python3 app.py --set-pin to configure. Backward compatible when no .pincode exists. Includes
   Kubernetes Secret mount instructions in README.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Dashboard now requires 4-digit PIN authentication before access
  * PIN setup available via command-line utility with secure hashing
  * PIN entry overlay with numeric keypad UI for authentication

* **Documentation**
  * Added PIN security setup and configuration guide, including Kubernetes deployment instructions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->