### PR TITLE
fix: decrement read count in quick link cards when a read email is archived or deleted

### DIFF
--- a/static/dashboard.js
+++ b/static/dashboard.js
@@ -1237,9 +1237,21 @@ async function emailAction(action, email, itemEl) {
             }
             buttons.forEach(b => b.remove());
 
-            // Decrement the quick link badge only if email was unread
+            // Decrement the quick link badge (unread) or read counter (read email)
             const groupName = currentSummaryGroup?.name;
-            if (groupName && email.isUnread) {
+            if (groupName && !email.isUnread) {
+                const ql = Array.from(quickLinksContainer.querySelectorAll('.quick-link'))
+                    .find(el => el.dataset.label === groupName);
+                if (ql) {
+                    const readSpan = ql.querySelector('.quick-link-read');
+                    if (readSpan) {
+                        const match = readSpan.textContent.match(/\+(\d+)/);
+                        const current = match ? parseInt(match[1], 10) : 0;
+                        const next = Math.max(0, current - 1);
+                        readSpan.textContent = next > 0 ? `+${next} read` : '';
+                    }
+                }
+            } else if (groupName && email.isUnread) {
                 const ql = Array.from(quickLinksContainer.querySelectorAll('.quick-link'))
                     .find(el => el.dataset.label === groupName);
                 if (ql) {


### PR DESCRIPTION
When archiving or deleting a read email from the summary pane, the "+N read" counter in the quick link card now decrements correctly. Previously only unread emails triggered a badge update.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed read/unread email counter tracking in quick-access lists to display accurate counts.
  * Corrected alignment between section-level and header-level unread email counters for consistent status tracking across the dashboard.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->