### PR TITLE
build(deps): update Python dependencies to latest stable versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,13 +11,13 @@ license = {text = "MIT"}
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
-    "mcp>=1.27.1",
-    "google-auth>=2.53.0",
+    "mcp>=1.29.0,<2.0.0",  # 2.0.0 removes the Server.list_tools()/call_tool() decorator API used here; requires a dedicated migration
+    "google-auth>=2.56.3",
     "google-auth-oauthlib>=1.4.0",
-    "google-auth-httplib2>=0.4.0",
-    "google-api-python-client>=2.196.0",
+    "google-auth-httplib2>=0.4.1",
+    "google-api-python-client>=2.198.0",
     "flask>=3.1.3",
-    "starlette>=1.1.0",
+    "starlette>=1.6.0",
     "cryptography>=50.0.0",  # transitive via google-auth; pinned to fix CVE-2026-69247 (GHSA-g6cj-pr64-35w5)
 ]
 
@@ -30,11 +30,11 @@ include = ["gmail_mcp_server*"]
 
 [project.optional-dependencies]
 dev = [
-    "pytest>=8.0",
-    "pytest-cov>=5.0",
-    "pytest-asyncio>=0.23",
-    "pytest-mock>=3.14",
-    "ruff>=0.4",
+    "pytest>=9.1.1",
+    "pytest-cov>=7.1.0",
+    "pytest-asyncio>=1.4.0",
+    "pytest-mock>=3.15.1",
+    "ruff>=0.16.2",
 ]
 
 [tool.ruff]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,10 @@
-mcp>=1.27.1
-google-auth>=2.53.0
+# 2.0.0 removes the Server.list_tools()/call_tool() decorator API used here; requires a dedicated migration
+mcp>=1.29.0,<2.0.0
+google-auth>=2.56.3
 google-auth-oauthlib>=1.4.0
-google-auth-httplib2>=0.4.0
-google-api-python-client>=2.196.0
+google-auth-httplib2>=0.4.1
+google-api-python-client>=2.198.0
 flask>=3.1.3
-starlette>=1.1.0
+starlette>=1.6.0
 # Transitive dependency of google-auth; pinned to fix CVE-2026-69247 (GHSA-g6cj-pr64-35w5)
 cryptography>=50.0.0


### PR DESCRIPTION
## Dependency update summary

### Packages updated
| Package | Old version | New version | Tool |
|---------|-------------|-------------|------|
| google-auth | >=2.53.0 | >=2.56.3 | pip |
| google-auth-httplib2 | >=0.4.0 | >=0.4.1 | pip |
| google-api-python-client | >=2.196.0 | >=2.198.0 | pip |
| starlette | >=1.1.0 | >=1.6.0 | pip |
| pytest (dev) | >=8.0 | >=9.1.1 | pip |
| pytest-cov (dev) | >=5.0 | >=7.1.0 | pip |
| pytest-asyncio (dev) | >=0.23 | >=1.4.0 | pip |
| pytest-mock (dev) | >=3.14 | >=3.15.1 | pip |
| ruff (dev) | >=0.4 | >=0.16.2 | pip |
| mcp | >=1.27.1 | >=1.29.0,<2.0.0 | pip |

Unchanged (already at latest stable): `flask` (3.1.3), `google-auth-oauthlib` (1.4.0), `cryptography` (50.0.0, previously pinned for CVE-2026-69247).

### Note on `mcp` 2.0.0
`mcp` 2.0.0 is available on PyPI but removes the `Server.list_tools()` / `Server.call_tool()` decorator API that `gmail_mcp_server/server.py` relies on. Installing it breaks the app at import/runtime and fails 6 tests outright (43 more error out as a consequence). Migrating to the new API is a non-trivial rewrite, out of scope for a routine dependency bump, so the constraint was bumped to the latest compatible `1.x` release (`1.29.0`) with an explicit `<2.0.0` upper bound (and an inline comment) to prevent an accidental future break. A follow-up task should track migrating to `mcp` 2.0.0.

### Verification
- [x] Pre-update CVE scan: clean (`pip-audit`)
- [x] Lint: passing (`ruff check .`)
- [x] Tests: passing (121 passed)
- [x] Post-update CVE scan: clean (`pip-audit`)

`safety check` could not be run in this environment (it requires reaching the Safety Platform auth service, which is not reachable here); `pip-audit` was used as the primary/cross-check CVE gate and reported no known vulnerabilities before or after the update.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated runtime and development dependency minimum versions.
  * Constrained `mcp` to compatible 1.x releases and added migration guidance.
  * Added an explicit `cryptography` version requirement.
  * Raised minimum versions for Google authentication, Google API, and web framework packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->