### PR TITLE
ci: fix auto-merge-deps workflow eligibility and hardening

### DIFF
--- a/.github/workflows/auto-merge-deps.yaml
+++ b/.github/workflows/auto-merge-deps.yaml
@@ -40,7 +40,7 @@ jobs:
             .[] | select(
               (.author.login == "jnpacker") and
               (
-                (.headRefName | test("^(fix|build|deps)/(go|python)-(deps|update)-")) or
+                (.headRefName | test("^(fix|build|deps)/(deps-)?(go|python)(-deps)?(-update)?-")) or
                 (.labels // [] | any(.name == "automated-update"))
               ) and
               (.mergeable == "MERGEABLE") and
@@ -94,7 +94,7 @@ jobs:
 
             # Note in the merge comment which eligibility path matched, so
             # it's clear from the audit trail why the PR qualified.
-            if echo "$pr_branch" | grep -qE "^(fix|build|deps)/(go|python)-(deps|update)-"; then
+            if echo "$pr_branch" | grep -qE "^(fix|build|deps)/(deps-)?(go|python)(-deps)?(-update)?-"; then
               pr_match_reason="branch: $pr_branch"
             else
               pr_match_reason="label: automated-update, branch: $pr_branch"
@@ -146,8 +146,9 @@ jobs:
             echo "## Auto-merge workflow summary"
             echo ""
             echo "Checked for dependency PRs authored by jnpacker that either match"
-            echo "branches like \`fix/{go,python}-deps-*\`, \`build/{go,python}-deps-*\`, or"
-            echo "\`deps/{go,python}-update-*\`, or carry the \`automated-update\` label, and have:"
+            echo "branches matching \`(fix|build|deps)/[deps-]{go,python}[-deps][-update]-*\`"
+            echo "(the deps- prefix, -deps suffix, and -update suffix are each optional), or"
+            echo "carry the \`automated-update\` label, and have:"
             echo "- All status checks passing (SUCCESS)"
             echo "- Mergeable state (no conflicts)"
             echo ""

--- a/.github/workflows/auto-merge-deps.yaml
+++ b/.github/workflows/auto-merge-deps.yaml
@@ -3,12 +3,10 @@ name: Auto-merge Dependency Updates
 on:
   workflow_dispatch:
   schedule:
-    # Every 30 min, 13:30-17:00 UTC, Mon-Fri.
-    # Covers 9:30am-12pm ET across both EDT (UTC-4) and EST (UTC-5), since
+    # Every 30 min, 12:00-17:00 UTC, Mon-Fri.
+    # Covers 8am-1pm ET across both EDT (UTC-4) and EST (UTC-5), since
     # GitHub Actions cron is UTC-only and does not observe DST.
-    - cron: "30 13 * * 1-5" # 13:30 UTC
-    - cron: "0,30 14-16 * * 1-5" # 14:00, 14:30, 15:00, 15:30, 16:00, 16:30 UTC
-    - cron: "0 17 * * 1-5" # 17:00 UTC
+    - cron: "0,30 12-17 * * 1-5" # 12:00, 12:30, ..., 16:30, 17:00 UTC
 
 jobs:
   auto-merge:
@@ -18,25 +16,39 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Get eligible dependency PRs
         id: get_prs
         run: |
-          # Only PRs authored by the trusted jnpacker PAT identity, targeting
-          # main, on a dependency-update branch (created by the
-          # swarm-deps-agent bot), are eligible for auto-merge. Also require
-          # the PR to be mergeable and every non-tide check to have
-          # completed successfully (not just "at least one success" - a
-          # pending check must not count as passing).
-          prs=$(gh pr list --state open --base main --json number,title,url,author,headRefName,headRefOid,statusCheckRollup,mergeable --jq '
+          set -euo pipefail
+
+          # Only PRs authored by the trusted jnpacker PAT identity,
+          # targeting main, are eligible for auto-merge. In addition, the
+          # PR must either be on a dependency-update branch (created by the
+          # swarm-deps-agent bot) or carry the "automated-update" label.
+          # Also require the PR to be mergeable and every non-tide check to
+          # have completed successfully (not just "at least one success" -
+          # a pending check must not count as passing). Note: GitHub
+          # computes `mergeable` asynchronously, so a PR can transiently
+          # report "UNKNOWN" on one API call and "MERGEABLE" moments later
+          # once GitHub finishes the check - this is expected and not
+          # something to special-case here.
+          prs=$(gh pr list --state open --base main --limit 100 --json number,title,url,author,headRefName,headRefOid,statusCheckRollup,mergeable,labels --jq '
             .[] | select(
               (.author.login == "jnpacker") and
-              (.headRefName | test("^(fix|build)/(go|python)-deps-")) and
+              (
+                (.headRefName | test("^(fix|build|deps)/(go|python)-(deps|update)-")) or
+                (.labels // [] | any(.name == "automated-update"))
+              ) and
               (.mergeable == "MERGEABLE") and
               ([.statusCheckRollup[] | select(.context != "tide" and .name != "tide")] as $checks |
                 ($checks | length > 0) and
-                ($checks | all(.state == "SUCCESS" or .conclusion == "SUCCESS")))
+                ($checks | all(
+                  ((.state // "" | ascii_upcase) == "SUCCESS") or
+                  ((.conclusion // "" | ascii_upcase) == "SUCCESS"))))
             )')
 
           if [ -z "$prs" ]; then
@@ -53,16 +65,26 @@ jobs:
           GH_TOKEN: ${{ github.token }}
 
       - name: Auto-merge ready PRs
+        id: merge_prs
         if: steps.get_prs.outputs.ready_prs != '[]'
         run: |
+          set -uo pipefail
+
           # Read the PR list from an environment variable rather than
           # interpolating it directly into the script, since it contains
           # contributor-controlled PR titles that could otherwise break out
           # of the quoted assignment and inject shell commands.
           ready_prs="$READY_PRS"
 
+          merged_count=0
+          queued_count=0
+          failed_count=0
+
           echo "Processing PRs for auto-merge..."
-          echo "$ready_prs" | jq -r '.[] | .number' | while read -r pr_number; do
+          # Feed the loop via process substitution (not a pipe) so it runs
+          # in the current shell, letting merged_count/queued_count/failed_count
+          # survive past the loop for the step outputs below.
+          while read -r pr_number; do
             echo "Processing PR #$pr_number"
 
             pr_info=$(echo "$ready_prs" | jq -r ".[] | select(.number == $pr_number)")
@@ -70,31 +92,70 @@ jobs:
             pr_branch=$(echo "$pr_info" | jq -r '.headRefName')
             pr_head_oid=$(echo "$pr_info" | jq -r '.headRefOid')
 
+            # Note in the merge comment which eligibility path matched, so
+            # it's clear from the audit trail why the PR qualified.
+            if echo "$pr_branch" | grep -qE "^(fix|build|deps)/(go|python)-(deps|update)-"; then
+              pr_match_reason="branch: $pr_branch"
+            else
+              pr_match_reason="label: automated-update, branch: $pr_branch"
+            fi
+
             echo "Attempting to merge PR #$pr_number: $pr_title (branch: $pr_branch)"
 
             # --match-head-commit binds the merge to the exact commit that
             # was evaluated for eligibility, so a push landing between the
             # eligibility check and this merge cannot slip in unreviewed.
             if gh pr merge "$pr_number" --squash --delete-branch --match-head-commit "$pr_head_oid"; then
-              echo "Successfully merged PR #$pr_number"
+              # gh pr merge can exit successfully after only queuing the PR
+              # (e.g. behind a merge queue), so confirm the actual state
+              # before reporting it as merged.
+              pr_state=$(gh pr view "$pr_number" --json state --jq '.state')
 
-              gh pr comment "$pr_number" --body "This PR was automatically merged because all checks passed and it matched the trusted dependency update pattern (author: jnpacker, branch: $pr_branch)."
+              if [ "$pr_state" = "MERGED" ]; then
+                echo "Successfully merged PR #$pr_number"
+                merged_count=$((merged_count + 1))
+
+                gh pr comment "$pr_number" --body "This PR was automatically merged because all checks passed and it matched the trusted dependency update pattern (author: jnpacker, $pr_match_reason)."
+              else
+                echo "PR #$pr_number was queued for merge (state: $pr_state), not yet merged"
+                queued_count=$((queued_count + 1))
+
+                gh pr comment "$pr_number" --body "This PR passed all checks and matched the trusted dependency update pattern (author: jnpacker, $pr_match_reason); it has been queued for merge."
+              fi
             else
               echo "Failed to merge PR #$pr_number"
+              failed_count=$((failed_count + 1))
 
               gh pr comment "$pr_number" --body "Auto-merge failed for this PR. Please check for conflicts or other issues."
             fi
 
             echo "---"
-          done
+          done < <(echo "$ready_prs" | jq -r '.[] | .number')
+
+          echo "merged_count=$merged_count" >> "$GITHUB_OUTPUT"
+          echo "queued_count=$queued_count" >> "$GITHUB_OUTPUT"
+          echo "failed_count=$failed_count" >> "$GITHUB_OUTPUT"
         env:
           GH_TOKEN: ${{ github.token }}
           READY_PRS: ${{ steps.get_prs.outputs.ready_prs }}
 
       - name: Summary
+        if: always()
         run: |
-          echo "Auto-merge workflow completed"
-          echo "Checked for dependency PRs authored by jnpacker on branches matching"
-          echo "fix/{go,python}-deps-* or build/{go,python}-deps-* that have:"
-          echo "- All status checks passing (SUCCESS)"
-          echo "- Mergeable state (no conflicts)"
+          {
+            echo "## Auto-merge workflow summary"
+            echo ""
+            echo "Checked for dependency PRs authored by jnpacker that either match"
+            echo "branches like \`fix/{go,python}-deps-*\`, \`build/{go,python}-deps-*\`, or"
+            echo "\`deps/{go,python}-update-*\`, or carry the \`automated-update\` label, and have:"
+            echo "- All status checks passing (SUCCESS)"
+            echo "- Mergeable state (no conflicts)"
+            echo ""
+            echo "| Merged | Queued | Failed |"
+            echo "|---|---|---|"
+            echo "| ${MERGED_COUNT:-0} | ${QUEUED_COUNT:-0} | ${FAILED_COUNT:-0} |"
+          } | tee -a "$GITHUB_STEP_SUMMARY"
+        env:
+          MERGED_COUNT: ${{ steps.merge_prs.outputs.merged_count }}
+          QUEUED_COUNT: ${{ steps.merge_prs.outputs.queued_count }}
+          FAILED_COUNT: ${{ steps.merge_prs.outputs.failed_count }}


### PR DESCRIPTION
Brings this repo's `auto-merge-deps.yaml` up to date with the fixes worked out in `stolostron/jira-mcp-server`'s version of the workflow:

- **Branch pattern**: widened to `^(fix|build|deps)/(go|python)-(deps|update)-` (adds the `deps/` prefix and `update` middle segment).
- **Label-based eligibility**: PRs carrying the `automated-update` label are now also eligible, independent of branch name.
- **Case-insensitive check state/conclusion matching**: `state`/`conclusion` are upper-cased before comparison to `SUCCESS`, and null-safe (`// ""`).
- **Match-reason audit trail**: the merge comment now records whether the branch pattern or the label matched.
- **Hardening**: SHA-pinned `actions/checkout`, `persist-credentials: false`, `set -euo pipefail`, `--limit 100` on `gh pr list`, verifies actual merge state (`MERGED` vs queued) before reporting, emits a `$GITHUB_STEP_SUMMARY` table.
- **Schedule**: simplified to a single `0,30 12-17 * * 1-5` cron, starting earlier (12:00 UTC) so the window reliably covers business hours across both EDT and EST.

No functional changes to the trust boundary — author identity (`jnpacker`) remains the sole authorization check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved automated dependency update handling.
  * Added clearer eligibility checks for dependency pull requests.
  * Added safer merge verification and separate reporting for merged, queued, and failed updates.
  * Added workflow summaries showing processing criteria and results.
  * Scheduled dependency processing to run on weekday business hours.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->